### PR TITLE
Remove Google Auth

### DIFF
--- a/backend/graphql/types/authType.ts
+++ b/backend/graphql/types/authType.ts
@@ -21,7 +21,6 @@ const authType = gql`
 
   extend type Mutation {
     login(email: String!, password: String!): AuthDTO!
-    loginWithGoogle(idToken: String!): AuthDTO!
     register(user: RegisterUserDTO!): AuthDTO!
     refresh: String!
     logout(userId: ID!): ID

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -152,16 +152,11 @@ class UserService implements IUserService {
     let firebaseUser: firebaseAdmin.auth.UserRecord;
 
     try {
-      if (signUpMethod === "GOOGLE") {
-        /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-        firebaseUser = await firebaseAdmin.auth().getUser(authId!);
-      } else {
-        // signUpMethod === PASSWORD
-        firebaseUser = await firebaseAdmin.auth().createUser({
-          email: user.email,
-          password: user.password,
-        });
-      }
+
+      firebaseUser = await firebaseAdmin.auth().createUser({
+        email: user.email,
+        password: user.password,
+      });
 
       try {
         newUser = await MgUser.create({

--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -38,41 +38,6 @@ const login = async (
   return user;
 };
 
-type LoginWithGoogleFunction = (
-  options?:
-    | MutationFunctionOptions<
-      { loginWithGoogle: AuthenticatedUser },
-      OperationVariables
-    >
-    | undefined,
-) => Promise<
-  FetchResult<
-    { loginWithGoogle: AuthenticatedUser },
-    Record<string, unknown>,
-    Record<string, unknown>
-  >
->;
-
-const loginWithGoogle = async (
-  idToken: string,
-  loginFunction: LoginWithGoogleFunction,
-): Promise<AuthenticatedUser | null> => {
-  let user: AuthenticatedUser = null;
-  try {
-    const result = await loginFunction({
-      variables: { idToken },
-    });
-    user = result.data?.loginWithGoogle ?? null;
-    if (user) {
-      localStorage.setItem(AUTHENTICATED_USER_KEY, JSON.stringify(user));
-    }
-  } catch (e: unknown) {
-    // eslint-disable-next-line no-alert
-    window.alert("Failed to login");
-  }
-  return user;
-};
-
 type RegisterFunction = (
   options?:
     | MutationFunctionOptions<
@@ -176,6 +141,6 @@ const refresh = async (refreshFunction: RefreshFunction): Promise<boolean> => {
   return success;
 };
 
-export default { login, logout, loginWithGoogle, register, refresh };
+export default { login, logout, register, refresh };
 
 

--- a/frontend/src/components/auth/Login.tsx
+++ b/frontend/src/components/auth/Login.tsx
@@ -1,10 +1,5 @@
 import React, { useContext, useState } from "react";
 import { Redirect, useHistory } from "react-router-dom";
-import {
-  GoogleLogin,
-  GoogleLoginResponse,
-  GoogleLoginResponseOffline,
-} from "react-google-login";
 import { gql, useMutation } from "@apollo/client";
 
 import authAPIClient from "../../APIClients/AuthAPIClient";
@@ -12,30 +7,9 @@ import { HOME_PAGE, SIGNUP_PAGE } from "../../constants/Routes";
 import AuthContext from "../../contexts/AuthContext";
 import { AuthenticatedUser } from "../../types/AuthTypes";
 
-type GoogleResponse = GoogleLoginResponse | GoogleLoginResponseOffline;
-
-type GoogleErrorResponse = {
-  error: string;
-  details: string;
-};
-
 const LOGIN = gql`
   mutation Login($email: String!, $password: String!) {
     login(email: $email, password: $password) {
-      id
-      firstName
-      lastName
-      email
-      town
-      role
-      accessToken
-    }
-  }
-`;
-
-const LOGIN_WITH_GOOGLE = gql`
-  mutation LoginWithGoogle($idToken: String!) {
-    loginWithGoogle(idToken: $idToken) {
       id
       firstName
       lastName
@@ -54,9 +28,6 @@ const Login = (): React.ReactElement => {
   const history = useHistory();
 
   const [login] = useMutation<{ login: AuthenticatedUser }>(LOGIN);
-  const [loginWithGoogle] = useMutation<{ loginWithGoogle: AuthenticatedUser }>(
-    LOGIN_WITH_GOOGLE,
-  );
 
   const onLogInClick = async () => {
     const user: AuthenticatedUser = await authAPIClient.login(
@@ -69,14 +40,6 @@ const Login = (): React.ReactElement => {
 
   const onSignUpClick = () => {
     history.push(SIGNUP_PAGE);
-  };
-
-  const onGoogleLoginSuccess = async (idToken: string) => {
-    const user: AuthenticatedUser = await authAPIClient.loginWithGoogle(
-      idToken,
-      loginWithGoogle,
-    );
-    setAuthenticatedUser(user);
   };
 
   if (authenticatedUser) {
@@ -112,22 +75,6 @@ const Login = (): React.ReactElement => {
             Log In
           </button>
         </div>
-        <GoogleLogin
-          clientId={process.env.REACT_APP_OAUTH_CLIENT_ID || ""}
-          buttonText="Login with Google"
-          onSuccess={(response: GoogleResponse): void => {
-            if ("tokenId" in response) {
-              onGoogleLoginSuccess(response.tokenId);
-            } else {
-              // eslint-disable-next-line no-alert
-              window.alert(response);
-            }
-          }}
-          onFailure={(error: GoogleErrorResponse) =>
-            // eslint-disable-next-line no-alert
-            window.alert(JSON.stringify(error))
-          }
-        />
       </form>
       <div>
         <button


### PR DESCRIPTION
## Implementation Description
Since we already removed some parts of google auth in a past PR, Emma suggested I delete it from the frontend auth service, at which point I figured I'd just nuke Google Auth from the codebase. Perhaps it's because I hold a grudge from them rejecting my application, but it saves us work down the line. The google auth code still exists in start code in case we want to reuse the design pattern.

## Screenshots
Login screen with no google auth:
![image](https://user-images.githubusercontent.com/62576642/151719860-9367153a-331a-4d93-b403-fb947fd60167.png)


## What should reviewers focus on?
- That this didn't break anything else in auth

## Testing Procedure
- Try logging in, logging out, signup, other auth operations. 
- Completed tests: I've already tried singing up, then logging in, then logging out, seems to work fine. 