### PR TITLE
Implement Lesson API - Create and Delete

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -78,6 +78,8 @@ const graphQLMiddlewares = {
     logout: isAuthorizedByUserId("userId"),
     resetPassword: isAuthorizedByEmail("email"),
     createLesson: authorizedByAdmin(),
+    updateLesson: authorizedByAdmin(),
+    deleteLesson: authorizedByAdmin(),
   },
 };
 

--- a/backend/graphql/resolvers/lessonResolvers.ts
+++ b/backend/graphql/resolvers/lessonResolvers.ts
@@ -2,7 +2,8 @@ import LessonService from "../../services/implementations/lessonService";
 import {
   ILessonService,
   LessonResponseDTO,
-  LessonRequestDTO,
+  LessonCreateRequestDTO,
+  LessonUpdateRequestDTO,
 } from "../../services/interfaces/ILessonService";
 
 const lessonService: ILessonService = new LessonService();
@@ -19,14 +20,14 @@ const lessonResolvers = {
   Mutation: {
     createLesson: async (
       _parent: undefined,
-      { lesson }: { lesson: LessonRequestDTO },
+      { lesson }: { lesson: LessonCreateRequestDTO },
     ): Promise<LessonResponseDTO> => {
       const newLesson = await lessonService.createLesson(lesson);
       return newLesson;
     },
     updateLesson: async (
       _parent: undefined,
-      { id, lesson }: { id: string; lesson: LessonRequestDTO },
+      { id, lesson }: { id: string; lesson: LessonUpdateRequestDTO },
     ): Promise<LessonResponseDTO | null> => {
       return lessonService.updateLesson(id, lesson);
     },

--- a/backend/graphql/resolvers/lessonResolvers.ts
+++ b/backend/graphql/resolvers/lessonResolvers.ts
@@ -24,6 +24,18 @@ const lessonResolvers = {
       const newLesson = await lessonService.createLesson(lesson);
       return newLesson;
     },
+    updateLesson: async (
+      _parent: undefined,
+      { id, lesson }: { id: string; lesson: LessonRequestDTO },
+    ): Promise<LessonResponseDTO | null> => {
+      return lessonService.updateLesson(id, lesson);
+    },
+    deleteLesson: async (
+      _parent: undefined,
+      { id }: { id: string },
+    ): Promise<string> => {
+      return lessonService.deleteLesson(id);
+    },
   },
 };
 export default lessonResolvers;

--- a/backend/graphql/resolvers/lessonResolvers.ts
+++ b/backend/graphql/resolvers/lessonResolvers.ts
@@ -2,8 +2,8 @@ import LessonService from "../../services/implementations/lessonService";
 import {
   ILessonService,
   LessonResponseDTO,
-  LessonCreateRequestDTO,
-  LessonUpdateRequestDTO,
+  CreateLessonRequestDTO,
+  UpdateLessonRequestDTO,
 } from "../../services/interfaces/ILessonService";
 
 const lessonService: ILessonService = new LessonService();
@@ -20,14 +20,14 @@ const lessonResolvers = {
   Mutation: {
     createLesson: async (
       _parent: undefined,
-      { lesson }: { lesson: LessonCreateRequestDTO },
+      { lesson }: { lesson: CreateLessonRequestDTO },
     ): Promise<LessonResponseDTO> => {
       const newLesson = await lessonService.createLesson(lesson);
       return newLesson;
     },
     updateLesson: async (
       _parent: undefined,
-      { id, lesson }: { id: string; lesson: LessonUpdateRequestDTO },
+      { id, lesson }: { id: string; lesson: UpdateLessonRequestDTO },
     ): Promise<LessonResponseDTO | null> => {
       return lessonService.updateLesson(id, lesson);
     },

--- a/backend/graphql/types/lessonType.ts
+++ b/backend/graphql/types/lessonType.ts
@@ -14,8 +14,16 @@ const lessonType = gql`
     content: [Content!]
   }
 
-  input LessonRequestDTO {
+  input LessonCreateRequestDTO {
     course: ID!
+    title: String
+    description: String
+    image: String
+    content: [Content!]
+  }
+
+  input LessonUpdateRequestDTO {
+    course: ID
     title: String
     description: String
     image: String
@@ -27,8 +35,8 @@ const lessonType = gql`
   }
 
   extend type Mutation {
-    createLesson(lesson: LessonRequestDTO!): LessonResponseDTO!
-    updateLesson(id: ID!, lesson: LessonRequestDTO!): LessonResponseDTO!
+    createLesson(lesson: LessonCreateRequestDTO!): LessonResponseDTO!
+    updateLesson(id: ID!, lesson: LessonUpdateRequestDTO!): LessonResponseDTO!
     deleteLesson(id: ID!): ID!
   }
 `;

--- a/backend/graphql/types/lessonType.ts
+++ b/backend/graphql/types/lessonType.ts
@@ -28,6 +28,8 @@ const lessonType = gql`
 
   extend type Mutation {
     createLesson(lesson: LessonRequestDTO!): LessonResponseDTO!
+    updateLesson(id: ID!, lesson: LessonRequestDTO!): LessonResponseDTO!
+    deleteLesson(id: ID!): ID!
   }
 `;
 

--- a/backend/graphql/types/lessonType.ts
+++ b/backend/graphql/types/lessonType.ts
@@ -14,7 +14,7 @@ const lessonType = gql`
     content: [Content!]
   }
 
-  input LessonCreateRequestDTO {
+  input CreateLessonRequestDTO {
     course: ID!
     title: String
     description: String
@@ -22,7 +22,7 @@ const lessonType = gql`
     content: [Content!]
   }
 
-  input LessonUpdateRequestDTO {
+  input UpdateLessonRequestDTO {
     course: ID
     title: String
     description: String
@@ -35,8 +35,8 @@ const lessonType = gql`
   }
 
   extend type Mutation {
-    createLesson(lesson: LessonCreateRequestDTO!): LessonResponseDTO!
-    updateLesson(id: ID!, lesson: LessonUpdateRequestDTO!): LessonResponseDTO!
+    createLesson(lesson: CreateLessonRequestDTO!): LessonResponseDTO!
+    updateLesson(id: ID!, lesson: UpdateLessonRequestDTO!): LessonResponseDTO!
     deleteLesson(id: ID!): ID!
   }
 `;

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -2,8 +2,8 @@ import MgLesson, { Lesson } from "../../models/lesson.model";
 import {
   ILessonService,
   LessonResponseDTO,
-  LessonCreateRequestDTO,
-  LessonUpdateRequestDTO,
+  CreateLessonRequestDTO,
+  UpdateLessonRequestDTO,
 } from "../interfaces/ILessonService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
@@ -35,7 +35,7 @@ class LessonService implements ILessonService {
   }
 
   async createLesson(
-    lesson: LessonCreateRequestDTO,
+    lesson: CreateLessonRequestDTO,
   ): Promise<LessonResponseDTO> {
     let newLesson: Lesson;
     try {
@@ -58,7 +58,7 @@ class LessonService implements ILessonService {
 
   async updateLesson(
     id: string,
-    lesson: LessonUpdateRequestDTO,
+    lesson: UpdateLessonRequestDTO,
   ): Promise<LessonResponseDTO> {
     let updatedLesson: Lesson | null;
     try {

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -34,7 +34,9 @@ class LessonService implements ILessonService {
     };
   }
 
-  async createLesson(lesson: LessonCreateRequestDTO): Promise<LessonResponseDTO> {
+  async createLesson(
+    lesson: LessonCreateRequestDTO,
+  ): Promise<LessonResponseDTO> {
     let newLesson: Lesson;
     try {
       newLesson = await MgLesson.create(lesson);

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -1,8 +1,9 @@
 import MgLesson, { Lesson } from "../../models/lesson.model";
 import {
   ILessonService,
-  LessonRequestDTO,
   LessonResponseDTO,
+  LessonCreateRequestDTO,
+  LessonUpdateRequestDTO,
 } from "../interfaces/ILessonService";
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
@@ -33,7 +34,7 @@ class LessonService implements ILessonService {
     };
   }
 
-  async createLesson(lesson: LessonRequestDTO): Promise<LessonResponseDTO> {
+  async createLesson(lesson: LessonCreateRequestDTO): Promise<LessonResponseDTO> {
     let newLesson: Lesson;
     try {
       newLesson = await MgLesson.create(lesson);
@@ -55,7 +56,7 @@ class LessonService implements ILessonService {
 
   async updateLesson(
     id: string,
-    lesson: LessonRequestDTO,
+    lesson: LessonUpdateRequestDTO,
   ): Promise<LessonResponseDTO> {
     let updatedLesson: Lesson | null;
     try {

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -52,6 +52,51 @@ class LessonService implements ILessonService {
       content: newLesson.content,
     };
   }
+
+  async updateLesson(
+    id: string,
+    lesson: LessonRequestDTO,
+  ): Promise<LessonResponseDTO> {
+    let updatedLesson: Lesson | null;
+    try {
+      updatedLesson = await MgLesson.findByIdAndUpdate(id, lesson, {
+        new: true,
+        runValidators: true,
+      });
+      if (!updatedLesson) {
+        throw new Error(`Lesson id ${id} not found`);
+      }
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to update lesson. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+
+    return {
+      id: updatedLesson.id,
+      course: updatedLesson.course,
+      title: updatedLesson.title,
+      description: updatedLesson.description,
+      image: updatedLesson.image,
+      content: updatedLesson.content,
+    };
+  }
+
+  async deleteLesson(id: string): Promise<string> {
+    try {
+      const deletedLesson: Lesson | null = await MgLesson.findByIdAndDelete(id);
+      if (!deletedLesson) {
+        throw new Error(`Lesson id ${id} not found`);
+      }
+      return id;
+    } catch (error: unknown) {
+      Logger.error(
+        `Failed to delete lesson. Reason = ${getErrorMessage(error)}`,
+      );
+      throw error;
+    }
+  }
 }
 
 export default LessonService;

--- a/backend/services/interfaces/ILessonService.ts
+++ b/backend/services/interfaces/ILessonService.ts
@@ -1,10 +1,19 @@
-export interface LessonRequestDTO {
+export interface LessonCreateRequestDTO {
   course: string;
   title: string;
   description: string;
   image: string;
   content: [Record<string, unknown>];
 }
+
+export interface LessonUpdateRequestDTO {
+  course: string;
+  title: string;
+  description: string;
+  image: string;
+  content: [Record<string, unknown>];
+}
+
 
 export interface LessonResponseDTO {
   id: string;
@@ -25,15 +34,15 @@ export interface ILessonService {
   getLessonById(id: string): Promise<LessonResponseDTO>;
 
   /**
-   * create an Lesson with the fields given in the DTO, return created Lesson
+   * create a Lesson with the fields given in the DTO, return created Lesson
    * @param lesson to be created
    * @returns the created Lesson
    * @throws Error if creation fails
    */
-  createLesson(lesson: LessonRequestDTO): Promise<LessonResponseDTO>;
+  createLesson(lesson: LessonCreateRequestDTO): Promise<LessonResponseDTO>;
 
   /**
-   * create an Lesson with the fields given in the DTO, return created Lesson
+   * create a Lesson with the fields given in the DTO, return created Lesson
    * @param id lesson id
    * @param lesson to be updated
    * @returns the updated Lesson
@@ -41,11 +50,11 @@ export interface ILessonService {
    */
   updateLesson(
     id: string,
-    lesson: LessonRequestDTO,
+    lesson: LessonUpdateRequestDTO,
   ): Promise<LessonResponseDTO | null>;
 
   /**
-   * create an Lesson with the fields given in the DTO, return created Lesson
+   * create a Lesson with the fields given in the DTO, return created Lesson
    * @param id of lesson to be deleted
    * @returns id of lesson deleted
    * @throws Error if deletion fails

--- a/backend/services/interfaces/ILessonService.ts
+++ b/backend/services/interfaces/ILessonService.ts
@@ -14,7 +14,6 @@ export interface LessonUpdateRequestDTO {
   content: [Record<string, unknown>];
 }
 
-
 export interface LessonResponseDTO {
   id: string;
   course: string;

--- a/backend/services/interfaces/ILessonService.ts
+++ b/backend/services/interfaces/ILessonService.ts
@@ -31,4 +31,24 @@ export interface ILessonService {
    * @throws Error if creation fails
    */
   createLesson(lesson: LessonRequestDTO): Promise<LessonResponseDTO>;
+
+  /**
+   * create an Lesson with the fields given in the DTO, return created Lesson
+   * @param id lesson id
+   * @param lesson to be updated
+   * @returns the updated Lesson
+   * @throws Error if update fails
+   */
+  updateLesson(
+    id: string,
+    lesson: LessonRequestDTO,
+  ): Promise<LessonResponseDTO | null>;
+
+  /**
+   * create an Lesson with the fields given in the DTO, return created Lesson
+   * @param id of lesson to be deleted
+   * @returns id of lesson deleted
+   * @throws Error if deletion fails
+   */
+  deleteLesson(id: string): Promise<string>;
 }

--- a/backend/services/interfaces/ILessonService.ts
+++ b/backend/services/interfaces/ILessonService.ts
@@ -1,4 +1,4 @@
-export interface LessonCreateRequestDTO {
+export interface CreateLessonRequestDTO {
   course: string;
   title: string;
   description: string;
@@ -6,7 +6,7 @@ export interface LessonCreateRequestDTO {
   content: [Record<string, unknown>];
 }
 
-export interface LessonUpdateRequestDTO {
+export interface UpdateLessonRequestDTO {
   course: string;
   title: string;
   description: string;
@@ -38,10 +38,10 @@ export interface ILessonService {
    * @returns the created Lesson
    * @throws Error if creation fails
    */
-  createLesson(lesson: LessonCreateRequestDTO): Promise<LessonResponseDTO>;
+  createLesson(lesson: CreateLessonRequestDTO): Promise<LessonResponseDTO>;
 
   /**
-   * create a Lesson with the fields given in the DTO, return created Lesson
+   * create a Lesson with the fields given in the DTO, return updated Lesson
    * @param id lesson id
    * @param lesson to be updated
    * @returns the updated Lesson
@@ -49,11 +49,11 @@ export interface ILessonService {
    */
   updateLesson(
     id: string,
-    lesson: LessonUpdateRequestDTO,
+    lesson: UpdateLessonRequestDTO,
   ): Promise<LessonResponseDTO | null>;
 
   /**
-   * create a Lesson with the fields given in the DTO, return created Lesson
+   * create a Lesson with the fields given in the DTO, return deleted Lesson
    * @param id of lesson to be deleted
    * @returns id of lesson deleted
    * @throws Error if deletion fails


### PR DESCRIPTION
## Implementation Description
Added create and delete mutations for lessons!

## Screenshots
N/A Backend work

## What should reviewers focus on?
- Does this align with how we want to add new APIs? Are we relying properly on the entity example?
- Are the correct fields marked optional?

## Testing Procedure
Testing procedure:
- Go to <backend-url>/graphql, for me this is [http://localhost:5000/graphql](http://localhost:5000/graphql)
- Try out queries and mutations. Include some mutations that don't have default values included (eg. no description):
Mutation 
```
mutation{
// create a lesson
createLesson(lesson: {
    course: "ID",
    title:"Lesson 1",
    description:"this is a description",
    image:"https://picsum.photos/536/354",
    content: [""],
  }) {
    id,
    course,
    title,
    description,
    image,
    content,
  }
}
// change a parameter
updateLesson(id: string, lesson: {
    course: "ID",
    description:"this is a modified description!",
    content: [""],
  }) {
    id,
    course,
    title,
    description,
    image,
    content,
  }
}
// delete a lesson, and query to check if exists
deleteLesson(id: string) : {
  id
}
```

## Things to Note
- Additional dependencies/libraries you've added?
N/A
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)