### PR TITLE
Fix updatedCourse mutation return bug where id not on argument

### DIFF
--- a/backend/services/implementations/courseService.ts
+++ b/backend/services/implementations/courseService.ts
@@ -74,15 +74,12 @@ class CourseService implements ICourseService {
     id: string,
     course: CourseRequestDTO,
   ): Promise<CourseResponseDTO | null> {
+    let updatedCourse: Course | null;
     try {
-      const updatedCourse: Course | null = await MgCourse.findByIdAndUpdate(
-        id,
-        course,
-        {
-          new: true,
-          runValidators: true,
-        },
-      );
+      updatedCourse = await MgCourse.findByIdAndUpdate(id, course, {
+        new: true,
+        runValidators: true,
+      });
       if (!updatedCourse) {
         throw new Error(`Course id ${id} not found`);
       }
@@ -94,12 +91,12 @@ class CourseService implements ICourseService {
     }
 
     return {
-      id: course.id,
-      title: course.title,
-      description: course.description,
-      image: course.image,
-      previewImage: course.previewImage,
-      lessons: course.lessons,
+      id: updatedCourse.id,
+      title: updatedCourse.title,
+      description: updatedCourse.description,
+      image: updatedCourse.image,
+      previewImage: updatedCourse.previewImage,
+      lessons: updatedCourse.lessons,
     };
   }
 


### PR DESCRIPTION
## Implementation Description
Found a bug on the `UpdateCourse` mutation -> calls `id` property of passed course, which doesn't exist. Get from result returned from db instead
- Change from prev PR, this comment -> https://github.com/uwblueprint/rowan-house/pull/21#discussion_r795252898

## Screenshots
Visual depiction of PR

## What should reviewers focus on?
- Makes sense? 

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

See testing section in https://github.com/uwblueprint/rowan-house/pull/21

## Things to Note
- Additional dependencies/libraries you've added? None
- Things you'd want to know when coming back to the code after a few months Nothing new

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR -> just reference other PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)