### PR TITLE
Find linter error and add bash command to run linter

### DIFF
--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -1,10 +1,4 @@
-import {
-  CreateUserDTO,
-  Role,
-  SignUpMethod,
-  UpdateUserDTO,
-  UserDTO,
-} from "../../types";
+import { CreateUserDTO, Role, UpdateUserDTO, UserDTO } from "../../types";
 
 interface IUserService {
   /**

--- a/utils.sh
+++ b/utils.sh
@@ -1,0 +1,4 @@
+if [[ "$1" = "lint" ]]
+then
+    docker exec -it RHS-backend /bin/bash -c "yarn lint --fix"
+fi


### PR DESCRIPTION
## Implementation Description
Linter had suggestion in previous PR that I didn't touch, this fixes it and also adds a bash script that runs the linter in the backend with auto fix

## Screenshots
Visual depiction of PR
n/a

## What should reviewers focus on?
- Check that the command runs properly on your computer -> `bash util.sh lint`

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?
  
Think just run it

## Things to Note
- Additional dependencies/libraries you've added? nope
- Things you'd want to know when coming back to the code after a few months -> can add more things to utils.sh as common commands happen

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)