### PR TITLE
Implement aggregate user count by town query

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -62,6 +62,7 @@ const graphQLMiddlewares = {
     userById: authorizedByAdmin(),
     userByEmail: authorizedByAdmin(),
     users: authorizedByAdmin(),
+    userCountByTown: authorizedByAdmin(),
     lessonById: authorizedByAllRoles(),
   },
   Mutation: {

--- a/backend/graphql/resolvers/userResolvers.ts
+++ b/backend/graphql/resolvers/userResolvers.ts
@@ -34,6 +34,13 @@ const userResolvers = {
       const csv = await generateCSV<UserDTO>({ data: users });
       return csv;
     },
+    userCountByTown: async (
+      _parent: undefined,
+      { startDate, endDate }: { startDate?: string; endDate?: string },
+    ): Promise<string> => {
+      const result = await userService.getUserCountByTown(startDate, endDate);
+      return JSON.stringify(result);
+    },
   },
   Mutation: {
     createUser: async (

--- a/backend/graphql/types/userType.ts
+++ b/backend/graphql/types/userType.ts
@@ -37,6 +37,7 @@ const userType = gql`
     userByEmail(email: String!): UserDTO!
     users: [UserDTO!]!
     usersCSV: String!
+    userCountByTown(startDate: String, endDate: String): String!
   }
 
   extend type Mutation {

--- a/backend/services/interfaces/userService.ts
+++ b/backend/services/interfaces/userService.ts
@@ -49,6 +49,28 @@ interface IUserService {
   getUsers(): Promise<Array<UserDTO>>;
 
   /**
+   * Get user count by town, limited by date range
+   *  in which user was created
+   *
+   * Same date format: 'yyyy/mm/dd', eg. '1900/01/01'
+   *
+   * Sample return format:
+   * {
+   *  "Toronto": 2,
+   *  "Vancouver": 3,
+   *  "San Francisco": 88,
+   * }
+   *
+   * @param startDate start of date range to query
+   * @param endDate end of date range to query
+   * @throws Error if query fails
+   */
+  getUserCountByTown(
+    startDate?: string,
+    endDate?: string,
+  ): Promise<{ [key: string]: number }>;
+
+  /**
    * Create a user, email verification configurable
    * @param user the user to be created
    * @param authId the user's firebase auth id, optional


### PR DESCRIPTION
## Implementation Description
Rowan house wants to be able to query information about their users -- one such query is number of users per town, limited by a start and end date
- Uses objectId timestamps, autogenerated instead of creating our own field. Docs here -> https://docs.mongodb.com/manual/reference/method/ObjectId.getTimestamp/
- Returns JSON string (`"{\"Toronto\":2,\"Vancouver\":1}"`) which is easily understood and can be parsed
  - However, this is not labelled as town / userCount so please comment on whether it's clear and usable
- Future improvement in frontend -- limit input selection to prevent typos, etc.

## Screenshots
Visual depiction of PR **n/a**

## What should reviewers focus on?
- Does return format make sense?
- Do we need further granularity than `yyyy/mm/dd`?
- No frontend work in this ticket?

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

**Query endpoint**
(First, add users to the database. Hard to test right away since this relies on objectId timestamps -- which are autogenerated)
No parameters
```
{
  userCountByTown
}

```
Single date provided
- enddate: before all data, some data included, after all data, future
- startdate: before all data, some data included, after all data, future
```
{
  userCountByTown(endDate: "2022/01/01")
}
```
Both dates provided
- valid date rate (before < after)
- invalid (after < before)
- expect results within timerange
- do not expect result within timerange
- expect some results within time range
```
{
  userCountByTown(startDate: "2020/01/01", endDate: "2022/01/01")
}
```

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months
  - Did JSON string format work for frontend?

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)