### PR TITLE
Separate create and update course DTO objects for required params clarity

### DIFF
--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -1,6 +1,7 @@
 import CourseService from "../../services/implementations/courseService";
 import {
-  CourseRequestDTO,
+  CreateCourseRequestDTO,
+  UpdateCourseRequestDTO,
   CourseResponseDTO,
   ICourseService,
 } from "../../services/interfaces/ICourseService";
@@ -22,14 +23,14 @@ const courseResolvers = {
   Mutation: {
     createCourse: async (
       _parent: undefined,
-      { course }: { course: CourseRequestDTO },
+      { course }: { course: CreateCourseRequestDTO },
     ): Promise<CourseResponseDTO> => {
       const newCourse = await courseService.createCourse(course);
       return newCourse;
     },
     updateCourse: async (
       _parent: undefined,
-      { id, course }: { id: string; course: CourseRequestDTO },
+      { id, course }: { id: string; course: UpdateCourseRequestDTO },
     ): Promise<CourseResponseDTO | null> => {
       return courseService.updateCourse(id, course);
     },

--- a/backend/graphql/types/courseType.ts
+++ b/backend/graphql/types/courseType.ts
@@ -12,12 +12,22 @@ const courseType = gql`
     published: Boolean!
   }
 
-  input CourseRequestDTO {
+  input CreateCourseRequestDTO {
     title: String!
     description: String
     image: String
     previewImage: String
     lessons: [ID!]!
+    private: Boolean
+    published: Boolean
+  }
+
+  input UpdateCourseRequestDTO {
+    title: String
+    description: String
+    image: String
+    previewImage: String
+    lessons: [ID!]
     private: Boolean
     published: Boolean
   }
@@ -28,8 +38,8 @@ const courseType = gql`
   }
 
   extend type Mutation {
-    createCourse(course: CourseRequestDTO!): CourseResponseDTO!
-    updateCourse(id: ID!, course: CourseRequestDTO!): CourseResponseDTO
+    createCourse(course: CreateCourseRequestDTO!): CourseResponseDTO!
+    updateCourse(id: ID!, course: UpdateCourseRequestDTO!): CourseResponseDTO
     deleteCourse(id: ID!): ID
   }
 `;

--- a/backend/services/implementations/courseService.ts
+++ b/backend/services/implementations/courseService.ts
@@ -1,7 +1,8 @@
 import { getErrorMessage } from "../../utilities/errorUtils";
 import logger from "../../utilities/logger";
 import {
-  CourseRequestDTO,
+  CreateCourseRequestDTO,
+  UpdateCourseRequestDTO,
   CourseResponseDTO,
   ICourseService,
 } from "../interfaces/ICourseService";
@@ -54,7 +55,9 @@ class CourseService implements ICourseService {
     }
   }
 
-  async createCourse(course: CourseRequestDTO): Promise<CourseResponseDTO> {
+  async createCourse(
+    course: CreateCourseRequestDTO,
+  ): Promise<CourseResponseDTO> {
     let newCourse: Course | null;
     try {
       newCourse = await MgCourse.create(course);
@@ -78,7 +81,7 @@ class CourseService implements ICourseService {
 
   async updateCourse(
     id: string,
-    course: CourseRequestDTO,
+    course: UpdateCourseRequestDTO,
   ): Promise<CourseResponseDTO | null> {
     let updatedCourse: Course | null;
     try {

--- a/backend/services/interfaces/ICourseService.ts
+++ b/backend/services/interfaces/ICourseService.ts
@@ -1,5 +1,14 @@
-export interface CourseRequestDTO {
-  id: string;
+export interface CreateCourseRequestDTO {
+  title: string;
+  description: string;
+  image: string;
+  previewImage: string;
+  lessons: [string];
+  private: boolean;
+  published: boolean;
+}
+
+export interface UpdateCourseRequestDTO {
   title: string;
   description: string;
   image: string;
@@ -43,7 +52,7 @@ export interface ICourseService {
    * @returns the created Course
    * @throws Error if creation fails
    */
-  createCourse(course: CourseRequestDTO): Promise<CourseResponseDTO>;
+  createCourse(course: CreateCourseRequestDTO): Promise<CourseResponseDTO>;
 
   /**
    * update the Course with the given id with fields in the DTO, return updated Course
@@ -54,7 +63,7 @@ export interface ICourseService {
    */
   updateCourse(
     id: string,
-    course: CourseRequestDTO,
+    course: UpdateCourseRequestDTO,
   ): Promise<CourseResponseDTO | null>;
 
   /**


### PR DESCRIPTION
## Implementation Description
Result of discussion on separate DTO objects on create and update mutations -- want separate so that we can be clear which params are required on create vs. required for an update (not the same)

## Screenshots
n/a not frontend

## What should reviewers focus on?
- Missing any instances?
- Required params makes sense?

## Testing Procedure
- See testing section in https://github.com/uwblueprint/rowan-house/pull/21

## Things to Note
- Rebase will be needed, either on this one, or on https://github.com/uwblueprint/rowan-house/pull/50 
  - Was going to hold off on this one until #50 merges

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)