### PR TITLE
Implement Course API Client

### DIFF
--- a/frontend/src/APIClients/CourseAPIClient.ts
+++ b/frontend/src/APIClients/CourseAPIClient.ts
@@ -72,7 +72,7 @@ const createCourse = async (course: CourseRequest): Promise<CourseResponse> => {
 
 const updateCourse = async (
   id: string,
-  course: CourseRequest,
+  course: Partial<CourseRequest>,
 ): Promise<CourseResponse> => {
   const bearerToken = `Bearer ${getLocalStorageObjProperty(
     AUTHENTICATED_USER_KEY,

--- a/frontend/src/APIClients/CourseAPIClient.ts
+++ b/frontend/src/APIClients/CourseAPIClient.ts
@@ -1,0 +1,112 @@
+import baseAPIClient from "./BaseAPIClient";
+import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
+import { getLocalStorageObjProperty } from "../utils/LocalStorageUtils";
+
+export type CourseRequest = {
+  title: string;
+  description: string;
+  image: string;
+  previewImage: string;
+  lessons: [string];
+  private: boolean;
+  published: boolean;
+};
+
+export type CourseResponse = {
+  id: string;
+  title: string;
+  description: string;
+  image: string;
+  previewImage: string;
+  lessons: [string];
+  private: boolean;
+  published: boolean;
+};
+
+// TO DO: error handling
+
+const getCourse = async (id: string): Promise<CourseResponse> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.get(`/course/${id}`, {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    return error;
+  }
+};
+
+const getAllCourses = async (): Promise<CourseResponse[]> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.get("/course", {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    return error;
+  }
+};
+
+const createCourse = async (course: CourseRequest): Promise<CourseResponse> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.post("/course", course, {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    return error;
+  }
+};
+
+const updateCourse = async (
+  id: string,
+  course: CourseRequest,
+): Promise<CourseResponse> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.put(`/course/${id}`, course, {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    return error;
+  }
+};
+
+const deleteCourse = async (id: string): Promise<string> => {
+  const bearerToken = `Bearer ${getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  )}`;
+  try {
+    const { data } = await baseAPIClient.delete(`/course/${id}`, {
+      headers: { Authorization: bearerToken },
+    });
+    return data;
+  } catch (error) {
+    return error;
+  }
+};
+
+export default {
+  getCourse,
+  getAllCourses,
+  createCourse,
+  updateCourse,
+  deleteCourse,
+};


### PR DESCRIPTION
## Implementation Description
Adding a course api client!

## Screenshots
N/A

## What should reviewers focus on?
- Ensure that request and response types are appropriate.

## Testing Procedure
Steps to test:
1. Checkout branch [testing-course-api-client](https://github.com/uwblueprint/rowan-house/tree/testing-course-api-client); note - this branch was created from the course-api-client branch
2. Log in and change route to `/dummy`. (Open dev tools console to see console log statements)
3. Press the create button to create a course with the parameters in [lines 78-86](https://github.com/uwblueprint/rowan-house/commit/8355f9775db851c960dfc7dad89dc2f31caace60#diff-b73a84f2d8afa5dcb756949b432c36a1bb90adcf309ea9ce66337d02c9e74903R78-R86) of the Dummy component 
4. Refresh the page to see that the course has been created
5. To test the update method, access mongodb atlas and retrieve the id of the course you just created. Replace the id in [line 120](https://github.com/uwblueprint/rowan-house/commit/8355f9775db851c960dfc7dad89dc2f31caace60#diff-b73a84f2d8afa5dcb756949b432c36a1bb90adcf309ea9ce66337d02c9e74903R120)
6. Press on the update button. Refresh the page (or see mongodb atlas)  to see that the course title has been updated
7. Replace the id in[ line 121](https://github.com/uwblueprint/rowan-house/commit/8355f9775db851c960dfc7dad89dc2f31caace60#diff-b73a84f2d8afa5dcb756949b432c36a1bb90adcf309ea9ce66337d02c9e74903R121) with the course id.
8. Press the delete button. Refresh the page (or see mongodb atlas) to see that the course has been deleted.

## Things to Note
- Need to implement better error handling
- - Need to implement unit tests for all methods
- Considered extracting `bearerToken` as a constant in [AuthConstant](https://github.com/uwblueprint/rowan-house/blob/main/frontend/src/constants/AuthConstants.ts). Not sure if this is worth the effort - potentially something to consider in the future.

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)