### PR TITLE
Limit access to courses based on role and private/published attributes

### DIFF
--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -16,6 +16,7 @@ import IEmailService from "../../services/interfaces/emailService";
 import IUserService from "../../services/interfaces/userService";
 import { Role } from "../../types";
 import { CourseVisibilityAttributes } from "../../models/course.model";
+import { assertNever } from "../../utilities/errorUtils";
 
 const courseService: ICourseService = new CourseService();
 const userService: IUserService = new UserService();
@@ -30,8 +31,10 @@ const getCourseVisibilityAttributes = (
       return { private: false, published: true };
     case "Staff":
       return { published: true };
-    default:
+    case "Admin":
       return {};
+    default:
+      return assertNever(role);
   }
 };
 

--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -1,3 +1,4 @@
+import { AuthenticationError, ExpressContext } from "apollo-server-express";
 import CourseService from "../../services/implementations/courseService";
 import {
   CreateCourseRequestDTO,
@@ -5,8 +6,34 @@ import {
   CourseResponseDTO,
   ICourseService,
 } from "../../services/interfaces/ICourseService";
+import { getAccessToken } from "../../middlewares/auth";
+import IAuthService from "../../services/interfaces/authService";
+import AuthService from "../../services/implementations/authService";
+import nodemailerConfig from "../../nodemailer.config";
+import EmailService from "../../services/implementations/emailService";
+import UserService from "../../services/implementations/userService";
+import IEmailService from "../../services/interfaces/emailService";
+import IUserService from "../../services/interfaces/userService";
+import { Role } from "../../types";
+import { CourseVisibilityAttributes } from "../../models/course.model";
 
 const courseService: ICourseService = new CourseService();
+const userService: IUserService = new UserService();
+const emailService: IEmailService = new EmailService(nodemailerConfig);
+const authService: IAuthService = new AuthService(userService, emailService);
+
+const getCourseVisibilityAttributes = (
+  role: Role,
+): CourseVisibilityAttributes => {
+  switch (role) {
+    case "User":
+      return { private: false, published: true };
+    case "Staff":
+      return { published: true };
+    default:
+      return {};
+  }
+};
 
 const courseResolvers = {
   Query: {
@@ -16,8 +43,18 @@ const courseResolvers = {
     ): Promise<CourseResponseDTO> => {
       return courseService.getCourse(id);
     },
-    courses: async (): Promise<CourseResponseDTO[]> => {
-      return courseService.getCourses();
+    courses: async (context: ExpressContext): Promise<CourseResponseDTO[]> => {
+      const accessToken = getAccessToken(context.req);
+      if (!accessToken) {
+        throw new AuthenticationError(
+          "Failed authentication and/or authorization by role",
+        );
+      }
+
+      const role = await authService.getUserRoleByAccessToken(accessToken);
+      const attributes = getCourseVisibilityAttributes(role);
+
+      return courseService.getCourses(attributes);
     },
   },
   Mutation: {

--- a/backend/models/course.model.ts
+++ b/backend/models/course.model.ts
@@ -11,6 +11,11 @@ export interface Course extends Document {
   published: boolean;
 }
 
+export interface CourseVisibilityAttributes {
+  private?: boolean;
+  published?: boolean;
+}
+
 const CourseSchema: Schema = new Schema({
   title: {
     type: String,

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -146,6 +146,21 @@ class AuthService implements IAuthService {
     }
   }
 
+  async getUserRoleByAccessToken(accessToken: string): Promise<Role> {
+    try {
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
+        .auth()
+        .verifyIdToken(accessToken, true);
+      const userRole = await this.userService.getUserRoleByAuthId(
+        decodedIdToken.uid,
+      );
+      return userRole;
+    } catch (error) {
+      Logger.error(`Failed to get assigned user role`);
+      throw error;
+    }
+  }
+
   async isAuthorizedByUserId(
     accessToken: string,
     requestedUserId: string,

--- a/backend/services/implementations/courseService.ts
+++ b/backend/services/implementations/courseService.ts
@@ -6,7 +6,10 @@ import {
   CourseResponseDTO,
   ICourseService,
 } from "../interfaces/ICourseService";
-import MgCourse, { Course } from "../../models/course.model";
+import MgCourse, {
+  Course,
+  CourseVisibilityAttributes,
+} from "../../models/course.model";
 
 const Logger = logger(__filename);
 
@@ -36,9 +39,11 @@ class CourseService implements ICourseService {
     };
   }
 
-  async getCourses(): Promise<CourseResponseDTO[]> {
+  async getCourses(
+    queryConditions: CourseVisibilityAttributes,
+  ): Promise<CourseResponseDTO[]> {
     try {
-      const courses: Array<Course> = await MgCourse.find();
+      const courses: Array<Course> = await MgCourse.find(queryConditions);
       return courses.map((course) => ({
         id: course.id,
         title: course.title,

--- a/backend/services/interfaces/ICourseService.ts
+++ b/backend/services/interfaces/ICourseService.ts
@@ -1,3 +1,5 @@
+import { CourseVisibilityAttributes } from "../../models/course.model";
+
 export interface CreateCourseRequestDTO {
   title: string;
   description: string;
@@ -40,11 +42,13 @@ export interface ICourseService {
 
   /**
    * retrieve all Courses
-   * @param
+   * @param queryConditions CourseVisibilityAttributes object to filter courses
    * @returns returns array of Courses
    * @throws Error if retrieval fails
    */
-  getCourses(): Promise<CourseResponseDTO[]>;
+  getCourses(
+    queryConditions: CourseVisibilityAttributes,
+  ): Promise<CourseResponseDTO[]>;
 
   /**
    * create an Course with the fields given in the DTO, return created Course

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -52,6 +52,14 @@ interface IAuthService {
   isAuthorizedByRole(accessToken: string, roles: Set<Role>): Promise<boolean>;
 
   /**
+   * Returns user role based on access token
+   * @param accessToken user's access token
+   * @returns Role type
+   * @throws Error if no user role found
+   */
+  getUserRoleByAccessToken(accessToken: string): Promise<Role>;
+
+  /**
    * Determine if the provided access token is valid and issued to the requested user
    * @param accessToken user's access token
    * @param requestedUserId userId of requested user

--- a/backend/utilities/errorUtils.ts
+++ b/backend/utilities/errorUtils.ts
@@ -1,4 +1,8 @@
-/* eslint-disable-next-line import/prefer-default-export */
 export const getErrorMessage = (error: unknown): string => {
   return error instanceof Error ? error.message : "Unknown error occurred.";
+};
+
+// https://www.typescriptlang.org/docs/handbook/unions-and-intersections.html#union-exhaustiveness-checking
+export const assertNever = (x: never): never => {
+  throw new Error(`Unexpected value/type: ${x}`);
 };


### PR DESCRIPTION
## Implementation Description
Separates access to courses between (User) and (Staff, Admin):
- users only have access to courses marked `private: false` and `published: true`
- staff/admin have access to all courses

Changes resolver to fulfill with appropriate logic
- Chatting with internal tools about this approach -- https://uwblueprint.slack.com/archives/C021C0R7KM2/p1645989506184349

## What should reviewers focus on?
- Is this the right separation of logic across layers?

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

Not sure how to test at the moment since no test admin users... should check that it filters as expected for various combinations of `private` and `published` attributes

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)