### PR TITLE
Add custom text variants/styles, utils command for linting

### DIFF
--- a/frontend/src/theme/components/index.ts
+++ b/frontend/src/theme/components/index.ts
@@ -1,4 +1,5 @@
 import Button from "./button";
 import Input from "./input";
+import Text from "./text";
 
-export { Button, Input };
+export { Button, Input, Text };

--- a/frontend/src/theme/components/text.ts
+++ b/frontend/src/theme/components/text.ts
@@ -1,0 +1,68 @@
+const Text = {
+  baseStyle: {},
+  sizes: {},
+  variants: {
+    "display-lg": {
+      fontWeight: "semibold",
+      fontSize: "28px",
+      lineHeight: "140%",
+    },
+    "display-md": {
+      fontWeight: "semibold",
+      fontSize: "26px",
+      lineHeight: "140%",
+    },
+    "display-sm-sb": {
+      fontWeight: "semibold",
+      fontSize: "24px",
+      lineHeight: "150%",
+    },
+    "display-sm": {
+      fontWeight: "normal",
+      fontSize: "24px",
+      lineHeight: "150%",
+    },
+    heading: {
+      fontWeight: "semibold",
+      fontSize: "20px",
+      lineHeight: "150%",
+    },
+    subheading: {
+      fontWeight: "semibold",
+      fontSize: "16px",
+      lineHeight: "130%",
+    },
+    "button-sb": {
+      fontWeight: "semibold",
+      fontSize: "16px",
+      lineHeight: "24px",
+    },
+    button: {
+      fontWeight: "normal",
+      fontSize: "16px",
+      lineHeight: "24px",
+    },
+    body: {
+      fontWeight: "normal",
+      fontSize: "18px",
+      lineHeight: "140%",
+    },
+    "body-bold": {
+      fontWeight: "bold",
+      fontSize: "18px",
+      lineHeight: "150%",
+    },
+    "caption-md": {
+      fontWeight: "bold",
+      size: "16px",
+      lineHeight: "150%",
+    },
+    caption: {
+      fontWeight: "normal",
+      size: "16px",
+      lineHeight: "150%",
+    },
+  },
+};
+
+export default Text;

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -5,7 +5,7 @@ import colors from "./foundations/colors";
 
 import fonts from "./foundations/fonts";
 import fontSizes from "./foundations/fontSizes";
-import { Button, Input } from "./components";
+import { Button, Input, Text } from "./components";
 /**
  * This file is generated for providing a custom theme to Chakra UI
  *
@@ -15,7 +15,7 @@ import { Button, Input } from "./components";
 
 const overrides = {
   ...styles,
-  components: { Input, Button },
+  components: { Input, Button, Text },
   colors,
   fonts,
   fontSizes,

--- a/utils.sh
+++ b/utils.sh
@@ -1,4 +1,7 @@
-if [[ "$1" = "lint" ]]
+if [[ "$1" = "belint" ]]
 then
     docker exec -it RHS-backend /bin/bash -c "yarn lint --fix"
+elif [[ "$1" = "felint" ]]
+then
+    docker exec -it RHS-frontend /bin/bash -c "yarn lint --fix"
 fi


### PR DESCRIPTION
## Implementation Description
Initial few changes for course block ticket
- Only separating this into its own ticket to make sure the text stylings are available for all future frontend work (and so no duplication on this work)

## What should reviewers focus on?
- Please compare to the Figma -> https://www.figma.com/file/zh6zk2LJo0RodIHBVycylC/RHS-Design-System?node-id=217%3A9061
  - All styles should align exactly with values in `text.ts`
- What the heck is the `em` property supposed to be 

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

Utils script should be manually testable
-> on Mac, command is `bash utils.sh felint` // `bash utils.sh belint`
-> may not work on other platforms

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months -> find a fix for other platforms?

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)