### PR TITLE
Converting modules to an array, allow null response

### DIFF
--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -1,15 +1,10 @@
 import { AuthenticationError, ExpressContext } from "apollo-server-express";
-import { v4 as uuidv4 } from "uuid";
 import CourseService from "../../services/implementations/courseService";
 import {
   CreateCourseRequestDTO,
   UpdateCourseRequestDTO,
   CourseResponseDTO,
   ICourseService,
-  SerializedCourseResponseDTO,
-  ModuleDTO,
-  SerializedCreateCourseRequestDTO,
-  SerializedUpdateCourseRequestDTO,
 } from "../../services/interfaces/ICourseService";
 import { getAccessToken } from "../../middlewares/auth";
 import IAuthService from "../../services/interfaces/authService";
@@ -20,59 +15,13 @@ import UserService from "../../services/implementations/userService";
 import IEmailService from "../../services/interfaces/emailService";
 import IUserService from "../../services/interfaces/userService";
 import { Role } from "../../types";
-import { CourseVisibilityAttributes, Module } from "../../models/course.model";
+import { CourseVisibilityAttributes } from "../../models/course.model";
 import { assertNever } from "../../utilities/errorUtils";
 
 const courseService: ICourseService = new CourseService();
 const userService: IUserService = new UserService();
 const emailService: IEmailService = new EmailService(nodemailerConfig);
 const authService: IAuthService = new AuthService(userService, emailService);
-
-const serializeToModuleDTO = (modules: {
-  [id: string]: Module;
-}): ModuleDTO[] => {
-  return Object.entries(modules).map(([key, val]) => ({ id: key, ...val }));
-};
-
-const deserializeModuleDTO = (
-  moduleDTOs: ModuleDTO[],
-): { [id: string]: Module } => {
-  const modules: { [id: string]: Module } = {} as { [id: string]: Module };
-
-  moduleDTOs.forEach((moduleDTO) => {
-    const moduleObj = {
-      title: moduleDTO.title,
-      description: moduleDTO.description,
-      image: moduleDTO.image,
-      previewImage: moduleDTO.previewImage,
-      published: moduleDTO.published,
-      lessons: moduleDTO.lessons,
-    };
-
-    // If no UUID is defined, create one
-    modules[moduleDTO?.id ?? uuidv4()] = moduleObj;
-  });
-
-  return modules;
-};
-
-const serializeCourseResponse = (
-  course: CourseResponseDTO,
-): SerializedCourseResponseDTO => {
-  return {
-    ...course,
-    modules: serializeToModuleDTO(course.modules),
-  };
-};
-
-const deserializeCourseRequest = (
-  course: SerializedCreateCourseRequestDTO | SerializedUpdateCourseRequestDTO,
-): CreateCourseRequestDTO | UpdateCourseRequestDTO => {
-  return {
-    ...course,
-    modules: deserializeModuleDTO(course.modules),
-  };
-};
 
 const getCourseVisibilityAttributes = (
   role: Role,
@@ -94,16 +43,14 @@ const courseResolvers = {
     course: async (
       _parent: undefined,
       { id }: { id: string },
-    ): Promise<SerializedCourseResponseDTO> => {
-      return courseService
-        .getCourse(id)
-        .then((course) => serializeCourseResponse(course));
+    ): Promise<CourseResponseDTO> => {
+      return courseService.getCourse(id);
     },
     courses: async (
       _parent: any,
       _args: { [key: string]: any },
       context: ExpressContext,
-    ): Promise<SerializedCourseResponseDTO[]> => {
+    ): Promise<CourseResponseDTO[]> => {
       const accessToken = getAccessToken(context.req);
       if (!accessToken) {
         throw new AuthenticationError(
@@ -114,32 +61,22 @@ const courseResolvers = {
       const role = await authService.getUserRoleByAccessToken(accessToken);
       const attributes = getCourseVisibilityAttributes(role);
 
-      return courseService
-        .getCourses(attributes)
-        .then((courses) => courses.map(serializeCourseResponse));
+      return courseService.getCourses(attributes);
     },
   },
   Mutation: {
     createCourse: async (
       _parent: undefined,
-      { course }: { course: SerializedCreateCourseRequestDTO },
-    ): Promise<SerializedCourseResponseDTO> => {
-      const newCourse = await courseService
-        .createCourse(deserializeCourseRequest(course))
-        .then(serializeCourseResponse);
+      { course }: { course: CreateCourseRequestDTO },
+    ): Promise<CourseResponseDTO> => {
+      const newCourse = await courseService.createCourse(course);
       return newCourse;
     },
     updateCourse: async (
       _parent: undefined,
-      { id, course }: { id: string; course: SerializedUpdateCourseRequestDTO },
-    ): Promise<SerializedCourseResponseDTO | null> => {
-      return courseService
-        .updateCourse(id, deserializeCourseRequest(course))
-        .then((unserializedCourse) => {
-          return unserializedCourse
-            ? serializeCourseResponse(unserializedCourse)
-            : null;
-        });
+      { id, course }: { id: string; course: UpdateCourseRequestDTO },
+    ): Promise<CourseResponseDTO | null> => {
+      return courseService.updateCourse(id, course);
     },
     deleteCourse: async (
       _parent: undefined,

--- a/backend/graphql/types/courseType.ts
+++ b/backend/graphql/types/courseType.ts
@@ -4,11 +4,11 @@ const courseType = gql`
   type ModuleResponseDTO {
     id: ID!
     title: String!
-    description: String!
-    image: String!
-    previewImage: String!
+    description: String
+    image: String
+    previewImage: String
     published: Boolean!
-    lessons: [String]!
+    lessons: [String]
   }
 
   input ModuleRequestDTO {
@@ -17,17 +17,17 @@ const courseType = gql`
     description: String
     image: String
     previewImage: String
-    published: Boolean!
+    published: Boolean
     lessons: [String]
   }
 
   type CourseResponseDTO {
     id: ID!
     title: String!
-    description: String!
-    image: String!
-    previewImage: String!
-    modules: [ModuleResponseDTO!]!
+    description: String
+    image: String
+    previewImage: String
+    modules: [ModuleResponseDTO!]
     private: Boolean!
     published: Boolean!
   }
@@ -37,9 +37,9 @@ const courseType = gql`
     description: String
     image: String
     previewImage: String
-    modules: [ModuleRequestDTO!]!
-    private: Boolean!
-    published: Boolean!
+    modules: [ModuleRequestDTO!]
+    private: Boolean
+    published: Boolean
   }
 
   input UpdateCourseRequestDTO {
@@ -47,7 +47,7 @@ const courseType = gql`
     description: String
     image: String
     previewImage: String
-    modules: [ModuleRequestDTO!]!
+    modules: [ModuleRequestDTO!]
     private: Boolean
     published: Boolean
   }

--- a/backend/models/course.model.ts
+++ b/backend/models/course.model.ts
@@ -35,7 +35,7 @@ const ModuleSchema: Schema = new Schema({
     default: false,
   },
   lessons: [String],
-})
+});
 
 const CourseSchema: Schema = new Schema({
   title: {

--- a/backend/models/course.model.ts
+++ b/backend/models/course.model.ts
@@ -26,13 +26,17 @@ export interface CourseVisibilityAttributes {
 }
 
 const ModuleSchema: Schema = new Schema({
-  title: String,
+  title: {
+    type: String,
+    required: true,
+  },
   description: String,
   image: String,
   preview_image: String,
   published: {
     type: Boolean,
     default: false,
+    required: true,
   },
   lessons: [String],
 });

--- a/backend/models/course.model.ts
+++ b/backend/models/course.model.ts
@@ -15,7 +15,7 @@ export interface Course extends Document {
   description: string;
   image: string;
   previewImage: string;
-  modules: { [id: string]: Module };
+  modules: Module[];
   private: boolean;
   published: boolean;
 }
@@ -24,6 +24,18 @@ export interface CourseVisibilityAttributes {
   private?: boolean;
   published?: boolean;
 }
+
+const ModuleSchema: Schema = new Schema({
+  title: String,
+  description: String,
+  image: String,
+  preview_image: String,
+  published: {
+    type: Boolean,
+    default: false,
+  },
+  lessons: [String],
+})
 
 const CourseSchema: Schema = new Schema({
   title: {
@@ -40,14 +52,7 @@ const CourseSchema: Schema = new Schema({
     type: String,
   },
   modules: {
-    type: {
-      title: String,
-      description: String,
-      image: String,
-      preview_image: String,
-      published: Boolean,
-      lessons: [String],
-    },
+    type: [ModuleSchema],
   },
   private: {
     type: Boolean,

--- a/backend/services/interfaces/ICourseService.ts
+++ b/backend/services/interfaces/ICourseService.ts
@@ -18,7 +18,7 @@ export interface CreateCourseRequestDTO {
   description: string;
   image: string;
   previewImage: string;
-  modules: { [id: string]: Module };
+  modules: Module[];
   private: boolean;
   published: boolean;
 }
@@ -30,7 +30,7 @@ export interface UpdateCourseRequestDTO {
   previewImage: string;
   private: boolean;
   published: boolean;
-  modules: { [id: string]: Module };
+  modules: Module[];
 }
 
 export interface CourseResponseDTO {
@@ -41,7 +41,7 @@ export interface CourseResponseDTO {
   previewImage: string;
   private: boolean;
   published: boolean;
-  modules: { [id: string]: Module };
+  modules: Module[];
 }
 
 export interface SerializedCreateCourseRequestDTO

--- a/frontend/src/APIClients/types/CourseClientTypes.ts
+++ b/frontend/src/APIClients/types/CourseClientTypes.ts
@@ -1,31 +1,31 @@
-type Module = {
+export type Module = {
+  id: string;
   title: string;
-  description: string;
-  image: string;
-  previewImage: string;
+  description: string | null;
+  image: string | null;
+  previewImage: string | null;
   published: boolean;
-  lessons: string[];
+  lessons: string[] | null;
 };
 
-type ModulesById = { [id: string]: Module };
 
 export type CourseRequest = {
   title: string;
-  description: string;
-  image: string;
-  previewImage: string;
-  modules: ModulesById;
-  private: boolean;
-  published: boolean;
+  description?: string;
+  image?: string;
+  previewImage?: string;
+  modules?: Module[];
+  private?: boolean;
+  published?: boolean;
 };
 
 export type CourseResponse = {
   id: string;
   title: string;
-  description: string;
-  image: string;
-  previewImage: string;
-  modules: ModulesById;
+  description: string | null;
+  image: string | null;
+  previewImage: string | null;
+  modules: Module[] | null;
   private: boolean;
   published: boolean;
 };

--- a/frontend/src/APIClients/types/CourseClientTypes.ts
+++ b/frontend/src/APIClients/types/CourseClientTypes.ts
@@ -8,7 +8,6 @@ export type Module = {
   lessons: string[] | null;
 };
 
-
 export type CourseRequest = {
   title: string;
   description?: string;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,7 +98,7 @@ const App = (): React.ReactElement => {
                   />
                   <PrivateRoute
                     exact
-                    path={`${Routes.ADMIN_MODULE_EDITOR_BASE_ROUTE}/:courseID/:moduleID`}
+                    path={`${Routes.ADMIN_MODULE_EDITOR_BASE_ROUTE}/:courseID/:moduleIndex`}
                     component={ModuleEditor}
                   />
                   <Route exact path="*" component={NotFound} />

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -58,13 +58,13 @@ const CoursePreview = ({
         </Button>
       </Flex>
       <SimpleGrid templateColumns="repeat(auto-fit, 240px)" spacing={4}>
-        {modules.map((module) => (
+        {modules?.map((module) => (
           <ModulePreview
-            key={module.moduleId}
+            key={module.id}
+            id={module.id}
             courseId={courseId}
-            moduleId={module.moduleId}
             title={module.title}
-            imageLink={module.imageLink}
+            image={module.image}
             published={module.published}
           />
         ))}

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -58,10 +58,10 @@ const CoursePreview = ({
         </Button>
       </Flex>
       <SimpleGrid templateColumns="repeat(auto-fit, 240px)" spacing={4}>
-        {modules?.map((module) => (
+        {modules?.map((module, index) => (
           <ModulePreview
             key={module.id}
-            id={module.id}
+            index={index}
             courseId={courseId}
             title={module.title}
             image={module.image}

--- a/frontend/src/components/admin/CoursesOverviewTab.tsx
+++ b/frontend/src/components/admin/CoursesOverviewTab.tsx
@@ -5,13 +5,13 @@ import { SmallAddIcon } from "@chakra-ui/icons";
 import { dummyCourses } from "../../constants/DummyData";
 import CoursePreview from "./CoursePreview";
 import { COURSES } from "../../APIClients/queries/CourseQueries";
-import { CoursePreviewProps } from "../../types/AdminDashboardTypes";
+import { CourseResponse } from "../../APIClients/types/CourseClientTypes";
 
 const CoursesOverviewTab = (): React.ReactElement => {
-  const [courses, setCourses] = React.useState<CoursePreviewProps[] | null>();
+  const [courses, setCourses] = React.useState<CourseResponse[] | null>();
 
   const { loading, error } = useQuery<{
-    courses: Array<CoursePreviewProps>;
+    courses: Array<CourseResponse>;
   }>(COURSES, {
     onCompleted: (data) => {
       if (!data) setCourses(dummyCourses);
@@ -41,11 +41,11 @@ const CoursesOverviewTab = (): React.ReactElement => {
       <VStack spacing={12} mx={9}>
         {courses?.map((course) => (
           <CoursePreview
-            key={course.courseId}
-            courseId={course.courseId}
+            key={course.id}
+            courseId={course.id}
             title={course.title}
             description={course.description}
-            isPrivate={course.isPrivate}
+            isPrivate={course.private}
             modules={course.modules}
           />
         ))}

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -5,17 +5,17 @@ import EditActionsKebabMenu from "./EditActionsKebabMenu";
 import { ADMIN_MODULE_EDITOR_BASE_ROUTE } from "../../constants/Routes";
 import { DEFAULT_IMAGE } from "../../constants/DummyData";
 
-const buildEditModuleRoute = (courseId: string, moduleId: string): string =>
-  `${ADMIN_MODULE_EDITOR_BASE_ROUTE}/${courseId}/${moduleId}`;
+const buildEditModuleRoute = (courseId: string, index: number): string =>
+  `${ADMIN_MODULE_EDITOR_BASE_ROUTE}/${courseId}/${index}`;
 
 const ModulePreview = ({
-  id,
+  index,
   courseId,
   title,
   published,
   image,
 }: ModulePreviewProps): React.ReactElement => {
-  const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, id);
+  const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, index);
 
   return (
     <Box

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -3,18 +3,19 @@ import { Box, Flex, Link, Image, Tag, Text, VStack } from "@chakra-ui/react";
 import { ModulePreviewProps } from "../../types/AdminDashboardTypes";
 import EditActionsKebabMenu from "./EditActionsKebabMenu";
 import { ADMIN_MODULE_EDITOR_BASE_ROUTE } from "../../constants/Routes";
+import { DEFAULT_IMAGE } from "../../constants/DummyData";
 
 const buildEditModuleRoute = (courseId: string, moduleId: string): string =>
   `${ADMIN_MODULE_EDITOR_BASE_ROUTE}/${courseId}/${moduleId}`;
 
 const ModulePreview = ({
+  id,
   courseId,
-  moduleId,
   title,
   published,
-  imageLink,
+  image,
 }: ModulePreviewProps): React.ReactElement => {
-  const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, moduleId);
+  const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, id);
 
   return (
     <Box
@@ -28,7 +29,7 @@ const ModulePreview = ({
     >
       <Link href={EDIT_MODULE_ROUTE}>
         <Image
-          src={imageLink}
+          src={image || DEFAULT_IMAGE}
           alt="module-preview"
           height="160px"
           width="240px"

--- a/frontend/src/components/module-editor/SideBarModuleOverview.tsx
+++ b/frontend/src/components/module-editor/SideBarModuleOverview.tsx
@@ -10,7 +10,8 @@ import {
 
 const SideBarModuleOverview = (): React.ReactElement => {
   const context = useContext(EditorContext);
-  const { courseID, moduleID }: ModuleEditorParams = useParams();
+  const { courseID, moduleIndex }: ModuleEditorParams = useParams();
+  const moduleID = parseInt(moduleIndex, 10);
 
   if (!context) return <></>;
   const { state, dispatch } = context;
@@ -28,7 +29,7 @@ const SideBarModuleOverview = (): React.ReactElement => {
       type: "create-lesson",
       value: {
         course: courseID,
-        module: moduleID,
+        module: course.modules[moduleID].id,
         title,
         content: [
           {

--- a/frontend/src/components/pages/ModuleEditor.tsx
+++ b/frontend/src/components/pages/ModuleEditor.tsx
@@ -25,15 +25,17 @@ const ModuleEditor = (): React.ReactElement => {
       title: `Course ${courseID}`,
       description: "Hello",
       private: false,
-      modules: [{
-        id: "module-hash-1",
-        title: "Hello!",
-        description: `I am a module ${moduleIndex}`,
-        image: "",
-        previewImage: "",
-        published: true,
-        lessons: ["lesson-hash-1", "lesson-hash-2"],
-      }],
+      modules: [
+        {
+          id: "module-hash-1",
+          title: "Hello!",
+          description: `I am a module ${moduleIndex}`,
+          image: "",
+          previewImage: "",
+          published: true,
+          lessons: ["lesson-hash-1", "lesson-hash-2"],
+        },
+      ],
     };
 
     // TODO: Retrieve all lessons from the module

--- a/frontend/src/components/pages/ModuleEditor.tsx
+++ b/frontend/src/components/pages/ModuleEditor.tsx
@@ -14,7 +14,7 @@ import SideBar from "../module-editor/SideBar";
 import LessonViewer from "../module-editor/LessonViewer";
 
 const ModuleEditor = (): React.ReactElement => {
-  const { courseID, moduleID }: ModuleEditorParams = useParams();
+  const { courseID, moduleIndex }: ModuleEditorParams = useParams();
 
   const [state, dispatch] = useReducer(EditorContextReducer, null);
 
@@ -25,16 +25,15 @@ const ModuleEditor = (): React.ReactElement => {
       title: `Course ${courseID}`,
       description: "Hello",
       private: false,
-      modules: {
-        "module-hash-1": {
-          title: "Hello!",
-          description: `I am a module ${moduleID}`,
-          image: "",
-          previewImage: "",
-          published: true,
-          lessons: ["lesson-hash-1", "lesson-hash-2"],
-        },
-      },
+      modules: [{
+        id: "module-hash-1",
+        title: "Hello!",
+        description: `I am a module ${moduleIndex}`,
+        image: "",
+        previewImage: "",
+        published: true,
+        lessons: ["lesson-hash-1", "lesson-hash-2"],
+      }],
     };
 
     // TODO: Retrieve all lessons from the module
@@ -97,10 +96,10 @@ const ModuleEditor = (): React.ReactElement => {
         hasChanged: false,
       },
     });
-  }, [courseID, moduleID]);
+  }, [courseID, moduleIndex]);
 
   if (state) {
-    if (state.course.modules[moduleID] === undefined) {
+    if (state.course.modules[parseInt(moduleIndex, 10)] === undefined) {
       return <p>Module not found!</p>;
     }
 

--- a/frontend/src/constants/DummyData.ts
+++ b/frontend/src/constants/DummyData.ts
@@ -1,69 +1,93 @@
-import { CoursePreviewProps } from "../types/AdminDashboardTypes";
+import { CourseResponse } from "../APIClients/types/CourseClientTypes";
 
-const DEFAULT_IMAGE =
+export const DEFAULT_IMAGE =
   "https://res.cloudinary.com/practicaldev/image/fetch/s--JIe3p0M4--/c_limit%2Cf_auto%2Cfl_progressive%2Cq_auto%2Cw_880/https://dev-to-uploads.s3.amazonaws.com/i/093ewdrgyf1kedlhzs51.png";
 
 /* eslint-disable import/prefer-default-export */
 
-export const dummyCourses: Array<CoursePreviewProps> = [
+export const dummyCourses: Array<CourseResponse> = [
   {
-    courseId: "abcdefg",
+    id: "abcdefg",
     title: "Preventing Domestic Abuse",
     description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quis enim, nisi,
       et vitae eget sed id accumsan. Nunc nunc nisi, convallis sed habitasse arcu, urna
       elementum amet. Tellus turpis id pharetra, vitae lacus, ac scelerisque sed suscipit.
       Justo, quam a porttitor elit rhoncus, vitae. Urna egestas commodo, ultrices est.
       Nisl volutpat, metus proin fermentum euismod condimentum vitae pellentesque. Orci.`,
-    isPrivate: false,
+    image: null,
+    previewImage: null,
+    private: false,
+    published: false,
     modules: [
       {
-        moduleId: "a1",
+        id: "a1",
         title:
           "Recognizing Signs of Abuse Recognizing Signs of Abuse Recognizing Signs of Abuse",
         published: true,
-        imageLink: DEFAULT_IMAGE,
+        image: DEFAULT_IMAGE,
+        description: null,
+        previewImage: null,
+        lessons: null,
       },
       {
-        moduleId: "a2",
+        id: "a2",
         title: "Recognizing Signs of Abuse",
         published: false,
-        imageLink: DEFAULT_IMAGE,
+        image: DEFAULT_IMAGE,
+        description: null,
+        previewImage: null,
+        lessons: null,
       },
       {
-        moduleId: "a3",
+        id: "a3",
         title: "Recognizing Signs of Abuse",
         published: true,
-        imageLink: DEFAULT_IMAGE,
+        image: DEFAULT_IMAGE,
+        description: null,
+        previewImage: null,
+        lessons: null,
       },
     ],
   },
   {
-    courseId: "jklmnop",
+    id: "jklmnop",
     title: "Preventing Domestic Abuse",
     description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quis enim, nisi,
       et vitae eget sed id accumsan. Nunc nunc nisi, convallis sed habitasse arcu, urna
       elementum amet. Tellus turpis id pharetra, vitae lacus, ac scelerisque sed suscipit.
       Justo, quam a porttitor elit rhoncus, vitae. Urna egestas commodo, ultrices est.
       Nisl volutpat, metus proin fermentum euismod condimentum vitae pellentesque. Orci.`,
-    isPrivate: false,
+    image: null,
+    previewImage: null,
+    private: false,
+    published: false,
     modules: [
       {
-        moduleId: "b1",
+        id: "b1",
         title: "Recognizing Signs",
         published: false,
-        imageLink: DEFAULT_IMAGE,
+        image: DEFAULT_IMAGE,
+        description: null,
+        previewImage: null,
+        lessons: null,
       },
       {
-        moduleId: "b2",
+        id: "b2",
         title: "Recognizing",
         published: false,
-        imageLink: DEFAULT_IMAGE,
+        image: DEFAULT_IMAGE,
+        description: null,
+        previewImage: null,
+        lessons: null,
       },
       {
-        moduleId: "b3",
+        id: "b3",
         title: "Recognizing Signs of",
         published: true,
-        imageLink: DEFAULT_IMAGE,
+        image: DEFAULT_IMAGE,
+        description: null,
+        previewImage: null,
+        lessons: null,
       },
     ],
   },

--- a/frontend/src/reducers/ModuleEditorContextReducer.ts
+++ b/frontend/src/reducers/ModuleEditorContextReducer.ts
@@ -13,18 +13,16 @@ const createLesson = (
   lesson: LessonType,
 ): EditorStateType => {
   const newState = { ...state };
+  const moduleIndex = state.course.modules.findIndex((module) => module.id === lesson.module)
   // Check to make sure moduleID exists
-  console.assert(
-    Object.keys(newState.course.modules).includes(lesson.module),
-    `Invalid moduleID ${lesson.module}`,
-  );
+  console.assert(moduleIndex !== -1, `Invalid moduleID ${lesson.module}`);
   // TODO: Generate a new ID for the lesson and ensure no duplicates
   const lessonID = lesson.title;
   // Create the new lesson object
   newState.lessons[lessonID] = lesson;
   // Add the lesson ID to the modules
   // TODO: Object.keys does not guarantee order - fix in the future
-  newState.course.modules[lesson.module].lessons = Object.keys(
+  newState.course.modules[moduleIndex].lessons = Object.keys(
     newState.lessons,
   );
   // Focus on new lesson

--- a/frontend/src/reducers/ModuleEditorContextReducer.ts
+++ b/frontend/src/reducers/ModuleEditorContextReducer.ts
@@ -13,7 +13,9 @@ const createLesson = (
   lesson: LessonType,
 ): EditorStateType => {
   const newState = { ...state };
-  const moduleIndex = state.course.modules.findIndex((module) => module.id === lesson.module)
+  const moduleIndex = state.course.modules.findIndex(
+    (module) => module.id === lesson.module,
+  );
   // Check to make sure moduleID exists
   console.assert(moduleIndex !== -1, `Invalid moduleID ${lesson.module}`);
   // TODO: Generate a new ID for the lesson and ensure no duplicates
@@ -22,9 +24,7 @@ const createLesson = (
   newState.lessons[lessonID] = lesson;
   // Add the lesson ID to the modules
   // TODO: Object.keys does not guarantee order - fix in the future
-  newState.course.modules[moduleIndex].lessons = Object.keys(
-    newState.lessons,
-  );
+  newState.course.modules[moduleIndex].lessons = Object.keys(newState.lessons);
   // Focus on new lesson
   newState.focusedLesson = lessonID;
   return newState;

--- a/frontend/src/types/AdminDashboardTypes.ts
+++ b/frontend/src/types/AdminDashboardTypes.ts
@@ -1,18 +1,17 @@
-export interface Module {
-  moduleId: string;
-  title: string;
-  published: boolean;
-  imageLink: string;
-}
+import { Module } from "../APIClients/types/CourseClientTypes";
 
-export interface ModulePreviewProps extends Module {
+export interface ModulePreviewProps {
+  id: string;
   courseId: string;
+  title: string;
+  image: string | null;
+  published: boolean;
 }
 
 export interface CoursePreviewProps {
   courseId: string;
   title: string;
-  description?: string;
+  description: string | null;
   isPrivate: boolean;
-  modules: Array<Module>;
+  modules: Module[] | null;
 }

--- a/frontend/src/types/AdminDashboardTypes.ts
+++ b/frontend/src/types/AdminDashboardTypes.ts
@@ -1,7 +1,7 @@
 import { Module } from "../APIClients/types/CourseClientTypes";
 
 export interface ModulePreviewProps {
-  id: string;
+  index: number;
   courseId: string;
   title: string;
   image: string | null;

--- a/frontend/src/types/ModuleEditorTypes.ts
+++ b/frontend/src/types/ModuleEditorTypes.ts
@@ -15,7 +15,7 @@ export interface ModuleType {
   image: string;
   previewImage: string;
   published: boolean;
-  lessons: Array<string>;
+  lessons: string[];
 }
 
 export interface CourseType {

--- a/frontend/src/types/ModuleEditorTypes.ts
+++ b/frontend/src/types/ModuleEditorTypes.ts
@@ -4,12 +4,13 @@ export interface LessonType {
   title: string;
   description?: string;
   image?: string;
-  content: Array<ContentType>;
+  content: ContentType[];
 }
 
 export type LessonsType = Record<string, LessonType>;
 
 export interface ModuleType {
+  id: string;
   title: string;
   description?: string;
   image: string;
@@ -22,7 +23,7 @@ export interface CourseType {
   title: string;
   description?: string;
   private: boolean;
-  modules: Record<string, ModuleType>;
+  modules: ModuleType[];
 }
 
 // Content types
@@ -53,7 +54,7 @@ export interface ContentType {
 
 export interface ModuleEditorParams {
   courseID: string;
-  moduleID: string;
+  moduleIndex: string;
 }
 
 // Context types


### PR DESCRIPTION
## Implementation Description
There were a lot of files edited, but the main points are:
- Modules should now be a list of objects instead of a map
- Module Editor URL now uses the index of the module as the identifier for which module is being edited
- Response DTOs can now have null attributes to prevent GraphQL errors from occuring

## Screenshots
Same as before, not applicable.

## What should reviewers focus on?
- Should the URL of the module editor use the index of the array or still its ID?
- Make sure the admin dashboard still works!

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)