### PR TITLE
Admin Dashboard Modals

### DIFF
--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -9,7 +9,6 @@ import {
 import { onError } from "@apollo/client/link/error";
 import { setContext } from "@apollo/client/link/context";
 import { RetryLink } from "@apollo/client/link/retry";
-import { relayStylePagination } from "@apollo/client/utilities";
 import { createUploadLink } from "apollo-upload-client";
 import jwt from "jsonwebtoken";
 import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
@@ -107,13 +106,6 @@ const client = new ApolloClient({
   link: errorLink.concat(refreshDirectionalLink),
   cache: new InMemoryCache({
     addTypename: false,
-    typePolicies: {
-      Query: {
-        fields: {
-          storyTranslations: relayStylePagination(),
-        },
-      },
-    },
   }),
 });
 

--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -106,6 +106,7 @@ errorLink -> refreshDirectionalLink
 const client = new ApolloClient({
   link: errorLink.concat(refreshDirectionalLink),
   cache: new InMemoryCache({
+    addTypename: false,
     typePolicies: {
       Query: {
         fields: {

--- a/frontend/src/APIClients/types/CourseClientTypes.ts
+++ b/frontend/src/APIClients/types/CourseClientTypes.ts
@@ -1,4 +1,14 @@
-export interface Module {
+export interface ModuleRequest {
+  id?: string;
+  title: string;
+  description?: string | null;
+  image?: string | null;
+  previewImage?: string | null;
+  published?: boolean;
+  lessons?: string[] | null;
+}
+
+export interface ModuleResponse {
   id: string;
   title: string;
   description: string | null;
@@ -10,10 +20,10 @@ export interface Module {
 
 export interface CourseRequest {
   title: string;
-  description?: string;
-  image?: string;
-  previewImage?: string;
-  modules?: Module[];
+  description?: string | null;
+  image?: string | null;
+  previewImage?: string | null;
+  modules?: ModuleRequest[] | null;
   private?: boolean;
 }
 
@@ -23,6 +33,6 @@ export interface CourseResponse {
   description: string | null;
   image: string | null;
   previewImage: string | null;
-  modules: Module[] | null;
+  modules: ModuleResponse[] | null;
   private: boolean;
 }

--- a/frontend/src/APIClients/types/CourseClientTypes.ts
+++ b/frontend/src/APIClients/types/CourseClientTypes.ts
@@ -1,4 +1,4 @@
-export type Module = {
+export interface Module {
   id: string;
   title: string;
   description: string | null;
@@ -6,18 +6,18 @@ export type Module = {
   previewImage: string | null;
   published: boolean;
   lessons: string[] | null;
-};
+}
 
-export type CourseRequest = {
+export interface CourseRequest {
   title: string;
   description?: string;
   image?: string;
   previewImage?: string;
   modules?: Module[];
   private?: boolean;
-};
+}
 
-export type CourseResponse = {
+export interface CourseResponse {
   id: string;
   title: string;
   description: string | null;
@@ -25,4 +25,4 @@ export type CourseResponse = {
   previewImage: string | null;
   modules: Module[] | null;
   private: boolean;
-};
+}

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -9,37 +9,30 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import ModulePreview from "./ModulePreview";
-import { CoursePreviewProps } from "../../types/AdminDashboardTypes";
 import EditActionsKebabMenu from "./EditActionsKebabMenu";
 import DeleteModal from "../common/DeleteModal";
 import EditCourseModal from "./EditCourseModal";
+import { CourseResponse } from "../../APIClients/types/CourseClientTypes";
 
 enum ModalType {
   EDIT = "edit",
   DELETE = "delete",
 }
 
-const CoursePreview = ({
-  courseId,
-  title,
-  description,
-  isPrivate,
-  modules,
-}: CoursePreviewProps): React.ReactElement => {
+interface CoursePreviewProps {
+  course: CourseResponse;
+}
+
+const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [modalType, setModalType] = useState(ModalType.EDIT); // determines which modal is shown when isOpen is true
-  const [name, setName] = useState("");
-  const [desc, setDesc] = useState("");
-  const [visibility, setVisibility] = useState(false);
+  const { title, description, modules, id, private: isPrivate } = course;
 
   const onDeleteClick = () => {
     setModalType(ModalType.DELETE);
     onOpen();
   };
   const onEditClick = () => {
-    setName(title);
-    setDesc(description || "");
-    setVisibility(!isPrivate);
     setModalType(ModalType.EDIT);
     onOpen();
   };
@@ -95,10 +88,8 @@ const CoursePreview = ({
           <ModulePreview
             key={module.id}
             index={index}
-            courseId={courseId}
-            title={module.title}
-            image={module.image}
-            published={module.published}
+            courseId={id}
+            module={module}
           />
         ))}
       </SimpleGrid>
@@ -111,18 +102,7 @@ const CoursePreview = ({
         />
       )}
       {modalType === ModalType.EDIT && (
-        <EditCourseModal
-          type="Course"
-          name={name}
-          description={description || ""}
-          visibility={visibility}
-          isOpen={isOpen}
-          onConfirm={onClose}
-          onCancel={onClose}
-          setName={setName}
-          setDescription={setDesc}
-          setVisibility={setVisibility}
-        />
+        <EditCourseModal course={course} isOpen={isOpen} onClose={onClose} />
       )}
     </Box>
   );

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -12,7 +12,7 @@ import ModulePreview from "./ModulePreview";
 import EditActionsKebabMenu from "./EditActionsKebabMenu";
 import DeleteModal from "../common/DeleteModal";
 import EditCourseModal from "./EditCourseModal";
-import { CourseResponse } from "../../APIClients/types/CourseClientTypes";
+import { CourseResponse, Module } from "../../APIClients/types/CourseClientTypes";
 
 enum ModalType {
   EDIT = "edit",
@@ -26,7 +26,7 @@ interface CoursePreviewProps {
 const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [modalType, setModalType] = useState(ModalType.EDIT); // determines which modal is shown when isOpen is true
-  const { title, description, modules, id, private: isPrivate } = course;
+  const { title, description, modules, private: isPrivate } = course;
 
   const onDeleteClick = () => {
     setModalType(ModalType.DELETE);
@@ -36,6 +36,14 @@ const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
     setModalType(ModalType.EDIT);
     onOpen();
   };
+
+  const formatCourseRequest = (newModule: Module, moduleIndex: number) => {
+    if (!course.modules)
+      throw Error("Attempted to edit module when course does not contain modules");
+    // Copy other modules by reference due to the immutability of the data
+    const newModules = course.modules.map((oldModule, index) => moduleIndex === index ? newModule : oldModule);
+    return {...course, modules: newModules};
+  }
 
   return (
     <Box
@@ -87,9 +95,10 @@ const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
         {modules?.map((module, index) => (
           <ModulePreview
             key={module.id}
-            index={index}
-            courseId={id}
+            courseId={course.id}
             module={module}
+            index={index}
+            formatCourseRequest={formatCourseRequest}
           />
         ))}
       </SimpleGrid>

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -29,7 +29,7 @@ interface CoursePreviewProps {
   course: CourseResponse;
 }
 
-const refetchQueries = {refetchQueries: [ { query: COURSES } ]}
+const refetchQueries = {refetchQueries: [ { query: COURSES } ]};
 
 const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -48,18 +48,23 @@ const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
     onClose();
   }
 
-  const formatCourseRequest = (newModule: ModuleRequest, moduleIndex: number): [string, CourseRequest] => {
+  const formatCourseRequest = (moduleIndex: number, newModule?: ModuleRequest): [string, CourseRequest] => {
     if (!course.modules)
       throw Error("Attempted to edit module when course does not contain modules");
     let newModules = [];
     // Copy other modules by reference due to the immutability of the data
-    if (moduleIndex >= 0 && moduleIndex < course.modules.length)
-      newModules = course.modules.map((oldModule, index) => moduleIndex === index ? newModule : oldModule);
-    else
-      newModules = [... course.modules, newModule];
+    if (newModule) {
+      // If module index isn't valid, append the new module
+      if (moduleIndex >= 0 && moduleIndex < course.modules.length)
+        newModules = course.modules.map((oldModule, index) => moduleIndex === index ? newModule : oldModule);
+      else
+        newModules = [... course.modules, newModule];
+    // If no new module has been passed, remove the module
+    } else {
+      newModules = course.modules.filter((_, index) => moduleIndex !== index);
+    }
 
-    const temp = {...course, modules: newModules}
-    const {id, ...newCourse} = temp;
+    const {id, ...newCourse} = {...course, modules: newModules};
     return [id, newCourse];
   }
 
@@ -132,7 +137,7 @@ const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
         <EditCourseModal course={course} isOpen={isOpen} onClose={onClose} />
       )}
       {modalType === ModalType.CREATE_MODULE && (
-        <EditModuleModal isOpen={isOpen} onClose={onClose} formatCourseRequest={(m) => formatCourseRequest(m, -1)}/>
+        <EditModuleModal isOpen={isOpen} onClose={onClose} formatCourseRequest={(m) => formatCourseRequest(-1, m)}/>
       )}
     </Box>
   );

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -1,8 +1,23 @@
-import React from "react";
-import { Box, Button, Flex, Tag, Text, SimpleGrid } from "@chakra-ui/react";
+import React, { useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Tag,
+  Text,
+  SimpleGrid,
+  useDisclosure,
+} from "@chakra-ui/react";
 import ModulePreview from "./ModulePreview";
 import { CoursePreviewProps } from "../../types/AdminDashboardTypes";
 import EditActionsKebabMenu from "./EditActionsKebabMenu";
+import DeleteModal from "../common/DeleteModal";
+import EditCourseModal from "./EditCourseModal";
+
+enum ModalType {
+  EDIT = "edit",
+  DELETE = "delete",
+}
 
 const CoursePreview = ({
   courseId,
@@ -11,6 +26,24 @@ const CoursePreview = ({
   isPrivate,
   modules,
 }: CoursePreviewProps): React.ReactElement => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [modalType, setModalType] = useState(ModalType.EDIT); // determines which modal is shown when isOpen is true
+  const [name, setName] = useState("");
+  const [desc, setDesc] = useState("");
+  const [visibility, setVisibility] = useState(false);
+
+  const onDeleteClick = () => {
+    setModalType(ModalType.DELETE);
+    onOpen();
+  };
+  const onEditClick = () => {
+    setName(title);
+    setDesc(description || "");
+    setVisibility(!isPrivate);
+    setModalType(ModalType.EDIT);
+    onOpen();
+  };
+
   return (
     <Box
       className="course-preview"
@@ -39,8 +72,8 @@ const CoursePreview = ({
           )}
         </Flex>
         <EditActionsKebabMenu
-          handleEditDetailsClick={() => alert("Edit details")}
-          deleteFunction={() => true}
+          handleEditDetailsClick={() => onEditClick()}
+          deleteFunction={() => onDeleteClick()}
           showHorizontal
         />
       </Flex>
@@ -69,6 +102,28 @@ const CoursePreview = ({
           />
         ))}
       </SimpleGrid>
+      {modalType === ModalType.DELETE && (
+        <DeleteModal
+          name="Course"
+          isOpen={isOpen}
+          onConfirm={onClose}
+          onCancel={onClose}
+        />
+      )}
+      {modalType === ModalType.EDIT && (
+        <EditCourseModal
+          type="Course"
+          name={name}
+          description={description || ""}
+          visibility={visibility}
+          isOpen={isOpen}
+          onConfirm={onClose}
+          onCancel={onClose}
+          setName={setName}
+          setDescription={setDesc}
+          setVisibility={setVisibility}
+        />
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/admin/EditCourseModal.tsx
+++ b/frontend/src/components/admin/EditCourseModal.tsx
@@ -16,7 +16,7 @@ export interface EditCourseModalProps {
   course?: CourseResponse;
 }
 
-const refetchQueries = {refetchQueries: [{ query: COURSES }]};
+const refetchQueries = {refetchQueries: [ { query: COURSES } ]}
 
 const EditCourseModal = ({ course, onClose, isOpen }: EditCourseModalProps) => {
   const [title, setTitle] = useState(course?.title ?? "");
@@ -45,6 +45,8 @@ const EditCourseModal = ({ course, onClose, isOpen }: EditCourseModalProps) => {
       };
       console.log(newCourse);
       updateCourse({ variables: { id: course.id, course: newCourse } });
+    } else {
+      throw Error("Attempted to update course that doesn't exist")
     }
     onClose();
   };

--- a/frontend/src/components/admin/EditCourseModal.tsx
+++ b/frontend/src/components/admin/EditCourseModal.tsx
@@ -16,7 +16,7 @@ export interface EditCourseModalProps {
   course?: CourseResponse;
 }
 
-const refetchQueries = {refetchQueries: [ { query: COURSES } ]}
+const refetchQueries = {refetchQueries: [ { query: COURSES } ]};
 
 const EditCourseModal = ({ course, onClose, isOpen }: EditCourseModalProps) => {
   const [title, setTitle] = useState(course?.title ?? "");

--- a/frontend/src/components/admin/EditCourseModal.tsx
+++ b/frontend/src/components/admin/EditCourseModal.tsx
@@ -1,0 +1,60 @@
+import { Flex, Box, VStack } from "@chakra-ui/react";
+import React from "react";
+import { TextInput } from "../common/TextInput";
+import { Modal, ModalProps } from "../common/Modal";
+import { SwitchInput } from "../common/SwitchInput";
+import { TextArea } from "../common/TextArea";
+
+export interface EditCourseModalProps extends ModalProps {
+  type: string;
+  name: string;
+  description: string;
+  visibility: boolean;
+  setName: (value: string) => void;
+  setDescription: (value: string) => void;
+  setVisibility: (value: boolean) => void;
+}
+
+const EditCourseModal: React.FC<EditCourseModalProps> = (props) => {
+  const {
+    type,
+    name,
+    description,
+    visibility,
+    setName,
+    setDescription,
+    setVisibility,
+  } = props;
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Modal size="lg" header={`Edit ${type}`} {...props}>
+      <VStack>
+        <TextInput
+          name={`${type} Name:`}
+          label={`${type} Name:`}
+          defaultValue={name}
+          onChange={(e) => setName(e.target.value)}
+          isRequired
+        />
+        <TextInput
+          name={`${type} Description:`}
+          label={`${type} Description:`}
+          defaultValue={description}
+          onChange={(e) => setDescription(e.target.value)}
+          isRequired
+        />
+        <SwitchInput
+          name={`Visibility: ${visibility ? "Public" : "Private"}`}
+          enabledName="Public"
+          disabledName="Private"
+          isEnabled={visibility}
+          onChange={(e) => setVisibility(e.target.checked)}
+        />
+        <Box width={8} />
+      </VStack>
+    </Modal>
+  );
+};
+
+export default EditCourseModal;

--- a/frontend/src/components/admin/EditModuleModal.tsx
+++ b/frontend/src/components/admin/EditModuleModal.tsx
@@ -1,59 +1,52 @@
-import { Flex, Box, VStack, Image } from "@chakra-ui/react";
-import React from "react";
+import { Flex, VStack, Image } from "@chakra-ui/react";
+import React, { useState } from "react";
 import { TextInput } from "../common/TextInput";
 import { Modal, ModalProps } from "../common/Modal";
 import { SwitchInput } from "../common/SwitchInput";
 import { TextArea } from "../common/TextArea";
+import { DEFAULT_IMAGE } from "../../constants/DummyData";
+import { Module } from "../../APIClients/types/CourseClientTypes";
 
 export interface EditModuleModalProps extends ModalProps {
-  type: string;
-  name: string;
-  description: string;
-  visibility: boolean;
-  setName: (value: string) => void;
-  setDescription: (value: string) => void;
-  setVisibility: (value: boolean) => void;
+  module: Module;
 }
 
 const EditModuleModal: React.FC<EditModuleModalProps> = (props) => {
-  const {
-    type,
-    name,
-    description,
-    visibility,
-    setName,
-    setDescription,
-    setVisibility,
-  } = props;
+  const { module } = props;
+  const [title, setTitle] = useState(module.title ?? "");
+  const [isPublished, setVisibility] = useState(module.published ?? false);
+  const [description, setDescription] = useState(module.description ?? "");
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
-    <Modal size="xl" header={`Edit ${type}`} {...props}>
+    <Modal size="xl" header="Edit Module" {...props}>
       <Flex>
-        <Image boxSize="210px" mr={3} src="/sample.jpg" />
-        <VStack>
+        <VStack flex="1" pr="1rem">
+          <Image src={DEFAULT_IMAGE} borderRadius=".5rem" />
+          <SwitchInput
+            name="Published Status"
+            enabledName="Published"
+            disabledName="Draft"
+            isEnabled={isPublished}
+            isSpaced={false}
+            onChange={(e) => setVisibility(e.target.checked)}
+          />
+        </VStack>
+        <VStack flex="1">
           <TextInput
-            name={`${type} Name:`}
-            label={`${type} Name:`}
-            defaultValue={name}
-            onChange={(e) => setName(e.target.value)}
+            name="Module Name:"
+            label="Module Name:"
+            defaultValue={title}
+            onChange={(e) => setTitle(e.target.value)}
             isRequired
           />
           <TextArea
-            name={`${type} Description:`}
-            label={`${type} Description:`}
+            name="Module Description:"
+            label="Module Description:"
             defaultValue={description}
             onChange={(e) => setDescription(e.target.value)}
             isRequired
           />
-          <SwitchInput
-            name={`Visibility: ${visibility ? "Public" : "Private"}`}
-            enabledName="Public"
-            disabledName="Private"
-            isEnabled={visibility}
-            onChange={(e) => setVisibility(e.target.checked)}
-          />
-          <Box width={8} />
         </VStack>
       </Flex>
     </Modal>

--- a/frontend/src/components/admin/EditModuleModal.tsx
+++ b/frontend/src/components/admin/EditModuleModal.tsx
@@ -7,32 +7,30 @@ import { Modal } from "../common/Modal";
 import { SwitchInput } from "../common/SwitchInput";
 import { TextArea } from "../common/TextArea";
 import { DEFAULT_IMAGE } from "../../constants/DummyData";
-import { CourseResponse, Module } from "../../APIClients/types/CourseClientTypes";
+import { CourseRequest, CourseResponse, ModuleResponse, ModuleRequest } from "../../APIClients/types/CourseClientTypes";
 import { UPDATE_COURSE } from "../../APIClients/mutations/CourseMutations";
 import { COURSES } from "../../APIClients/queries/CourseQueries";
 
 export interface EditModuleModalProps {
   onClose: () => void;
   isOpen: boolean;
-  module: Module;
-  formatCourseRequest: (module: Module) => CourseResponse;
+  formatCourseRequest: (module: ModuleRequest) => [string, CourseRequest];
+  module?: ModuleResponse;
 }
 
-const refetchQueries = {refetchQueries: [{ query: COURSES }]};
+const refetchQueries = {refetchQueries: [ { query: COURSES } ]}
 
 const EditModuleModal = ({ module, formatCourseRequest, isOpen, onClose }: EditModuleModalProps) => {  
-  const [title, setTitle] = useState(module.title ?? "");
-  const [isPublished, setVisibility] = useState(module.published ?? false);
-  const [description, setDescription] = useState(module.description ?? "");
+  const [title, setTitle] = useState(module?.title ?? "");
+  const [isPublished, setVisibility] = useState(module?.published ?? false);
+  const [description, setDescription] = useState(module?.description ?? "");
   
   const [updateCourse] = useMutation<CourseResponse>(UPDATE_COURSE, refetchQueries);
 
   const onUpdateModule = () => {
     const newModule = {...module, title, description, published: isPublished};
-    const course = formatCourseRequest(newModule);
-    const {id, ...newCourse} = course;
-    console.log(newCourse);
-    updateCourse({ variables: { id, course: newCourse } });
+    const [id, course] = formatCourseRequest(newModule);
+    updateCourse({ variables: { id, course } });
     onClose();
   };
 

--- a/frontend/src/components/admin/EditModuleModal.tsx
+++ b/frontend/src/components/admin/EditModuleModal.tsx
@@ -1,0 +1,63 @@
+import { Flex, Box, VStack, Image } from "@chakra-ui/react";
+import React from "react";
+import { TextInput } from "../common/TextInput";
+import { Modal, ModalProps } from "../common/Modal";
+import { SwitchInput } from "../common/SwitchInput";
+import { TextArea } from "../common/TextArea";
+
+export interface EditModuleModalProps extends ModalProps {
+  type: string;
+  name: string;
+  description: string;
+  visibility: boolean;
+  setName: (value: string) => void;
+  setDescription: (value: string) => void;
+  setVisibility: (value: boolean) => void;
+}
+
+const EditModuleModal: React.FC<EditModuleModalProps> = (props) => {
+  const {
+    type,
+    name,
+    description,
+    visibility,
+    setName,
+    setDescription,
+    setVisibility,
+  } = props;
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Modal size="xl" header={`Edit ${type}`} {...props}>
+      <Flex>
+        <Image boxSize="210px" mr={3} src="/sample.jpg" />
+        <VStack>
+          <TextInput
+            name={`${type} Name:`}
+            label={`${type} Name:`}
+            defaultValue={name}
+            onChange={(e) => setName(e.target.value)}
+            isRequired
+          />
+          <TextArea
+            name={`${type} Description:`}
+            label={`${type} Description:`}
+            defaultValue={description}
+            onChange={(e) => setDescription(e.target.value)}
+            isRequired
+          />
+          <SwitchInput
+            name={`Visibility: ${visibility ? "Public" : "Private"}`}
+            enabledName="Public"
+            disabledName="Private"
+            isEnabled={visibility}
+            onChange={(e) => setVisibility(e.target.checked)}
+          />
+          <Box width={8} />
+        </VStack>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default EditModuleModal;

--- a/frontend/src/components/admin/EditModuleModal.tsx
+++ b/frontend/src/components/admin/EditModuleModal.tsx
@@ -18,7 +18,7 @@ export interface EditModuleModalProps {
   module?: ModuleResponse;
 }
 
-const refetchQueries = {refetchQueries: [ { query: COURSES } ]}
+const refetchQueries = {refetchQueries: [ { query: COURSES } ]};
 
 const EditModuleModal = ({ module, formatCourseRequest, isOpen, onClose }: EditModuleModalProps) => {  
   const [title, setTitle] = useState(module?.title ?? "");

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -14,7 +14,7 @@ import DeleteModal from "../common/DeleteModal";
 import EditModuleModal from "./EditModuleModal";
 import { ADMIN_MODULE_EDITOR_BASE_ROUTE } from "../../constants/Routes";
 import { DEFAULT_IMAGE } from "../../constants/DummyData";
-import { Module } from "../../APIClients/types/CourseClientTypes";
+import { CourseResponse, Module } from "../../APIClients/types/CourseClientTypes";
 
 const buildEditModuleRoute = (courseId: string, index: number): string =>
   `${ADMIN_MODULE_EDITOR_BASE_ROUTE}/${courseId}/${index}`;
@@ -28,17 +28,19 @@ interface ModulePreviewProps {
   module: Module;
   courseId: string;
   index: number;
+  formatCourseRequest: (module: Module, index: number) => CourseResponse;
 }
 
 const ModulePreview = ({
   module,
   courseId,
   index,
+  formatCourseRequest,
 }: ModulePreviewProps): React.ReactElement => {
   const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, index);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [modalType, setModalType] = useState(ModalType.EDIT); // determines which modal is shown when isOpen is true
-
+  
   const { title, image, published } = module;
 
   const onDeleteClick = () => {
@@ -101,8 +103,8 @@ const ModulePreview = ({
         <EditModuleModal
           module={module}
           isOpen={isOpen}
-          onConfirm={onClose}
-          onCancel={onClose}
+          onClose={onClose}
+          formatCourseRequest={(m) => formatCourseRequest(m, index)}
         />
       )}
     </Box>

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -9,12 +9,12 @@ import {
   VStack,
   useDisclosure,
 } from "@chakra-ui/react";
-import { ModulePreviewProps } from "../../types/AdminDashboardTypes";
 import EditActionsKebabMenu from "./EditActionsKebabMenu";
 import DeleteModal from "../common/DeleteModal";
 import EditModuleModal from "./EditModuleModal";
 import { ADMIN_MODULE_EDITOR_BASE_ROUTE } from "../../constants/Routes";
 import { DEFAULT_IMAGE } from "../../constants/DummyData";
+import { Module } from "../../APIClients/types/CourseClientTypes";
 
 const buildEditModuleRoute = (courseId: string, index: number): string =>
   `${ADMIN_MODULE_EDITOR_BASE_ROUTE}/${courseId}/${index}`;
@@ -24,29 +24,28 @@ enum ModalType {
   DELETE = "delete",
 }
 
+interface ModulePreviewProps {
+  module: Module;
+  courseId: string;
+  index: number;
+}
+
 const ModulePreview = ({
-  index,
+  module,
   courseId,
-  title,
-  published,
-  image,
+  index,
 }: ModulePreviewProps): React.ReactElement => {
   const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, index);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [modalType, setModalType] = useState(ModalType.EDIT); // determines which modal is shown when isOpen is true
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [visibility, setVisibility] = useState(false);
 
+  const { title, image, published } = module;
 
   const onDeleteClick = () => {
     setModalType(ModalType.DELETE);
     onOpen();
   };
   const onEditClick = () => {
-    setName(title);
-    // description??
-    setVisibility(published);
     setModalType(ModalType.EDIT);
     onOpen();
   };
@@ -94,22 +93,16 @@ const ModulePreview = ({
         <DeleteModal
           name="Module"
           isOpen={isOpen}
-          onConfirm={() => true}
+          onConfirm={onClose}
           onCancel={onClose}
         />
       )}
       {modalType === ModalType.EDIT && (
         <EditModuleModal
-          type="Module"
-          name={name}
-          description={description}
-          visibility={visibility}
+          module={module}
           isOpen={isOpen}
-          onConfirm={() => true}
+          onConfirm={onClose}
           onCancel={onClose}
-          setName={setName}
-          setDescription={setDescription}
-          setVisibility={setVisibility}
         />
       )}
     </Box>

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -32,10 +32,10 @@ interface ModulePreviewProps {
   module: ModuleResponse;
   courseId: string;
   index: number;
-  formatCourseRequest: (module: ModuleRequest, index: number) => [string, CourseRequest];
+  formatCourseRequest: (index: number, module?: ModuleRequest) => [string, CourseRequest];
 }
 
-const refetchQueries = {refetchQueries: [ { query: COURSES } ]}
+const refetchQueries = {refetchQueries: [ { query: COURSES } ]};
 
 const ModulePreview = ({
   module,
@@ -57,7 +57,8 @@ const ModulePreview = ({
   };
 
   const onDeleteModule = () => {
-    updateCourse();
+    const [id, course] = formatCourseRequest(index);
+    updateCourse({ variables: { id, course } });
     onClose();
   }
 
@@ -113,7 +114,7 @@ const ModulePreview = ({
           module={module}
           isOpen={isOpen}
           onClose={onClose}
-          formatCourseRequest={(m) => formatCourseRequest(m, index)}
+          formatCourseRequest={(m) => formatCourseRequest(index, m)}
         />
       )}
     </Box>

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -1,12 +1,28 @@
-import React from "react";
-import { Box, Flex, Link, Image, Tag, Text, VStack } from "@chakra-ui/react";
+import React, { useState } from "react";
+import {
+  Box,
+  Flex,
+  Link,
+  Image,
+  Tag,
+  Text,
+  VStack,
+  useDisclosure,
+} from "@chakra-ui/react";
 import { ModulePreviewProps } from "../../types/AdminDashboardTypes";
 import EditActionsKebabMenu from "./EditActionsKebabMenu";
+import DeleteModal from "../common/DeleteModal";
+import EditModuleModal from "./EditModuleModal";
 import { ADMIN_MODULE_EDITOR_BASE_ROUTE } from "../../constants/Routes";
 import { DEFAULT_IMAGE } from "../../constants/DummyData";
 
 const buildEditModuleRoute = (courseId: string, index: number): string =>
   `${ADMIN_MODULE_EDITOR_BASE_ROUTE}/${courseId}/${index}`;
+
+enum ModalType {
+  EDIT = "edit",
+  DELETE = "delete",
+}
 
 const ModulePreview = ({
   index,
@@ -16,6 +32,24 @@ const ModulePreview = ({
   image,
 }: ModulePreviewProps): React.ReactElement => {
   const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, index);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [modalType, setModalType] = useState(ModalType.EDIT); // determines which modal is shown when isOpen is true
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibility, setVisibility] = useState(false);
+
+
+  const onDeleteClick = () => {
+    setModalType(ModalType.DELETE);
+    onOpen();
+  };
+  const onEditClick = () => {
+    setName(title);
+    // description??
+    setVisibility(published);
+    setModalType(ModalType.EDIT);
+    onOpen();
+  };
 
   return (
     <Box
@@ -51,11 +85,33 @@ const ModulePreview = ({
           </VStack>
         </Link>
         <EditActionsKebabMenu
-          handleEditDetailsClick={() => alert("edit details")}
-          deleteFunction={() => true}
+          handleEditDetailsClick={onEditClick}
+          deleteFunction={onDeleteClick}
           showHorizontal={false}
         />
       </Flex>
+      {modalType === ModalType.DELETE && (
+        <DeleteModal
+          name="Module"
+          isOpen={isOpen}
+          onConfirm={() => true}
+          onCancel={onClose}
+        />
+      )}
+      {modalType === ModalType.EDIT && (
+        <EditModuleModal
+          type="Module"
+          name={name}
+          description={description}
+          visibility={visibility}
+          isOpen={isOpen}
+          onConfirm={() => true}
+          onCancel={onClose}
+          setName={setName}
+          setDescription={setDescription}
+          setVisibility={setVisibility}
+        />
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/common/DeleteModal.tsx
+++ b/frontend/src/components/common/DeleteModal.tsx
@@ -5,7 +5,7 @@ export interface DeleteModalProps extends ModalProps {
   name: string;
 }
 
-const DeleteModal: React.FC<DeleteModalProps> = (props) => {
+const DeleteModal = (props: DeleteModalProps) => {
   const { name } = props;
 
   return (

--- a/frontend/src/components/common/DeleteModal.tsx
+++ b/frontend/src/components/common/DeleteModal.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Modal, ModalProps } from "./Modal";
+
+export interface DeleteModalProps extends ModalProps {
+  name: string;
+}
+
+const DeleteModal: React.FC<DeleteModalProps> = (props) => {
+  const { name } = props;
+
+  return (
+    <Modal
+      size="sm"
+      header={`Delete ${name}`}
+      bodyText={`Are you sure? You can't undo this action afterwards.`}
+      cancelButtonColorScheme="ghost"
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+  );
+};
+
+export default DeleteModal;

--- a/frontend/src/components/common/DeleteModal.tsx
+++ b/frontend/src/components/common/DeleteModal.tsx
@@ -13,7 +13,7 @@ const DeleteModal: React.FC<DeleteModalProps> = (props) => {
       size="sm"
       header={`Delete ${name}`}
       bodyText={`Are you sure? You can't undo this action afterwards.`}
-      cancelButtonColorScheme="ghost"
+      // cancelButtonColorScheme="ghost"
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}
     />

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable react/forbid-prop-types */
+import React from "react";
+import {
+  Button,
+  Modal as ChakraModal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Text,
+  Spacer,
+} from "@chakra-ui/react";
+
+export interface ModalProps {
+  isOpen: boolean;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onCancel: () => void;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onConfirm: () => void;
+  header?: string;
+  bodyText?: string;
+  cancelText?: string;
+  confirmText?: string;
+  alignButtonsRight?: boolean;
+  cancelButtonColorScheme?: string;
+  confirmButtonColorScheme?: string;
+  size?: string;
+  children?: React.ReactNode;
+}
+
+export const Modal: React.FC<ModalProps> = (props) => {
+  const {
+    isOpen,
+    onCancel,
+    onConfirm,
+    header,
+    bodyText,
+    cancelText = "Cancel",
+    confirmText = "Confirm",
+    alignButtonsRight = true,
+    cancelButtonColorScheme,
+    confirmButtonColorScheme,
+    children,
+    ...rest
+  } = props;
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <ChakraModal isCentered onClose={onCancel} isOpen={isOpen} {...rest}>
+      <ModalOverlay />
+      <ModalContent>
+        {header && <ModalHeader>{header}</ModalHeader>}
+        <ModalBody>
+          {bodyText && <Text>{bodyText}</Text>}
+          {/* eslint-disable-next-line react/destructuring-assignment */}
+          {props.children}
+        </ModalBody>
+        <ModalFooter>
+          <Button colorScheme={cancelButtonColorScheme} onClick={onCancel}>
+            {cancelText}
+          </Button>
+          {!alignButtonsRight && <Spacer />}
+          <Button
+            variant={confirmButtonColorScheme ? "solid" : "default"}
+            colorScheme={confirmButtonColorScheme}
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </ChakraModal>
+  );
+};

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -22,29 +22,23 @@ export interface ModalProps {
   bodyText?: string;
   cancelText?: string;
   confirmText?: string;
-  alignButtonsRight?: boolean;
-  cancelButtonColorScheme?: string;
-  confirmButtonColorScheme?: string;
+  spreadButtons?: boolean;
   size?: string;
   children?: React.ReactNode;
 }
 
-export const Modal: React.FC<ModalProps> = (props) => {
-  const {
-    isOpen,
-    onCancel,
-    onConfirm,
-    header,
-    bodyText,
-    cancelText = "Cancel",
-    confirmText = "Confirm",
-    alignButtonsRight = true,
-    cancelButtonColorScheme,
-    confirmButtonColorScheme,
-    children,
-    ...rest
-  } = props;
-
+export const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onCancel,
+  onConfirm,
+  header,
+  bodyText,
+  cancelText = "Cancel",
+  confirmText = "Confirm",
+  spreadButtons = false,
+  children,
+  ...rest
+}) => {
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <ChakraModal isCentered onClose={onCancel} isOpen={isOpen} {...rest}>
@@ -54,19 +48,15 @@ export const Modal: React.FC<ModalProps> = (props) => {
         <ModalBody>
           {bodyText && <Text>{bodyText}</Text>}
           {/* eslint-disable-next-line react/destructuring-assignment */}
-          {props.children}
+          {children}
         </ModalBody>
         <ModalFooter>
-          <Button colorScheme={cancelButtonColorScheme} onClick={onCancel}>
-            {cancelText}
-          </Button>
-          {!alignButtonsRight && <Spacer />}
-          <Button
-            variant={confirmButtonColorScheme ? "solid" : "default"}
-            colorScheme={confirmButtonColorScheme}
-            onClick={onConfirm}
-          >
+          <Button onClick={onConfirm} mr="1rem">
             {confirmText}
+          </Button>
+          {spreadButtons && <Spacer />}
+          <Button variant="outline" onClick={onCancel}>
+            {cancelText}
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -27,7 +27,7 @@ export interface ModalProps {
   children?: React.ReactNode;
 }
 
-export const Modal: React.FC<ModalProps> = ({
+export const Modal = ({
   isOpen,
   onCancel,
   onConfirm,
@@ -38,7 +38,7 @@ export const Modal: React.FC<ModalProps> = ({
   spreadButtons = false,
   children,
   ...rest
-}) => {
+}: ModalProps) => {
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <ChakraModal isCentered onClose={onCancel} isOpen={isOpen} {...rest}>

--- a/frontend/src/components/common/SwitchInput.tsx
+++ b/frontend/src/components/common/SwitchInput.tsx
@@ -1,0 +1,28 @@
+import { Switch, FormControl, FormLabel, InputProps } from "@chakra-ui/react";
+
+import React, { useState } from "react";
+
+export interface SwitchProps extends InputProps {
+  name: string;
+  isEnabled?: boolean;
+  enabledName?: string;
+  disabledName?: string;
+}
+
+export const SwitchInput: React.FC<SwitchProps> = ({
+  name,
+  isEnabled,
+  enabledName,
+  disabledName,
+}) => {
+  const [enabled, setEnabled] = useState(isEnabled);
+  const toggleLabel = () => {
+    setEnabled(!enabled);
+  };
+  return (
+    <FormControl display="flex" alignItems="center">
+      <FormLabel>{enabled ? enabledName : disabledName}</FormLabel>
+      <Switch id={name} defaultIsChecked={isEnabled} onChange={toggleLabel} />
+    </FormControl>
+  );
+};

--- a/frontend/src/components/common/SwitchInput.tsx
+++ b/frontend/src/components/common/SwitchInput.tsx
@@ -3,31 +3,36 @@ import {
   Switch,
   FormControl,
   FormLabel,
-  InputProps,
 } from "@chakra-ui/react";
 
 import React, { useState } from "react";
 
-export interface SwitchProps extends InputProps {
-  isEnabled?: boolean;
-  enabledName?: string;
-  disabledName?: string;
+export interface SwitchProps {
+  onChange: (result: boolean) => void;
+  isEnabled: boolean;
+  enabledName: string;
+  disabledName: string;
+  prefix?: string;
   isSpaced?: boolean;
 }
 
-export const SwitchInput: React.FC<SwitchProps> = ({
+export const SwitchInput = ({
+  onChange,
   isEnabled,
   enabledName,
   disabledName,
+  prefix = "",
   isSpaced = true,
-}) => {
+}: SwitchProps) => {
   const [enabled, setEnabled] = useState(isEnabled);
   const toggleLabel = () => {
     setEnabled(!enabled);
+    onChange(!enabled);
   };
+
   return (
     <FormControl display="flex" alignItems="center">
-      <FormLabel>{enabled ? enabledName : disabledName}</FormLabel>
+      <FormLabel>{prefix && `${prefix} `}{enabled ? enabledName : disabledName}</FormLabel>
       {isSpaced && <Spacer />}
       <Switch defaultIsChecked={isEnabled} onChange={toggleLabel} />
     </FormControl>

--- a/frontend/src/components/common/SwitchInput.tsx
+++ b/frontend/src/components/common/SwitchInput.tsx
@@ -1,19 +1,25 @@
-import { Switch, FormControl, FormLabel, InputProps } from "@chakra-ui/react";
+import {
+  Spacer,
+  Switch,
+  FormControl,
+  FormLabel,
+  InputProps,
+} from "@chakra-ui/react";
 
 import React, { useState } from "react";
 
 export interface SwitchProps extends InputProps {
-  name: string;
   isEnabled?: boolean;
   enabledName?: string;
   disabledName?: string;
+  isSpaced?: boolean;
 }
 
 export const SwitchInput: React.FC<SwitchProps> = ({
-  name,
   isEnabled,
   enabledName,
   disabledName,
+  isSpaced = true,
 }) => {
   const [enabled, setEnabled] = useState(isEnabled);
   const toggleLabel = () => {
@@ -22,7 +28,8 @@ export const SwitchInput: React.FC<SwitchProps> = ({
   return (
     <FormControl display="flex" alignItems="center">
       <FormLabel>{enabled ? enabledName : disabledName}</FormLabel>
-      <Switch id={name} defaultIsChecked={isEnabled} onChange={toggleLabel} />
+      {isSpaced && <Spacer />}
+      <Switch defaultIsChecked={isEnabled} onChange={toggleLabel} />
     </FormControl>
   );
 };

--- a/frontend/src/components/common/TextArea.tsx
+++ b/frontend/src/components/common/TextArea.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import {
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+  InputProps,
+  FormHelperText,
+  Textarea,
+} from "@chakra-ui/react";
+import { WarningIcon } from "@chakra-ui/icons";
+
+export interface TextAreaProps extends InputProps {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  errorMessage?: string;
+  helperText?: string;
+  isInvalid?: boolean;
+  isRequired?: boolean;
+}
+
+export const TextArea: React.FC<TextAreaProps> = ({
+  name,
+  label,
+  placeholder,
+  errorMessage,
+  helperText,
+  isInvalid,
+  isRequired,
+}) => {
+  return (
+    <FormControl id={name} isRequired={isRequired} isInvalid={isInvalid} mb={5}>
+      <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
+        {label}
+      </FormLabel>
+      <Textarea placeholder={placeholder} errorBorderColor="red.600" />
+      {errorMessage && (
+        <FormErrorMessage>
+          <WarningIcon mr={2} /> {errorMessage}
+        </FormErrorMessage>
+      )}
+      {helperText && !isInvalid && (
+        <FormHelperText>{helperText}</FormHelperText>
+      )}
+    </FormControl>
+  );
+};

--- a/frontend/src/components/common/TextArea.tsx
+++ b/frontend/src/components/common/TextArea.tsx
@@ -10,7 +10,6 @@ import {
 import { WarningIcon } from "@chakra-ui/icons";
 
 export interface TextAreaProps extends InputProps {
-  name: string;
   label?: string;
   placeholder?: string;
   errorMessage?: string;
@@ -20,7 +19,6 @@ export interface TextAreaProps extends InputProps {
 }
 
 export const TextArea: React.FC<TextAreaProps> = ({
-  name,
   label,
   placeholder,
   errorMessage,
@@ -29,7 +27,12 @@ export const TextArea: React.FC<TextAreaProps> = ({
   isRequired,
 }) => {
   return (
-    <FormControl id={name} isRequired={isRequired} isInvalid={isInvalid} mb={5}>
+    <FormControl
+      id={label}
+      isRequired={isRequired}
+      isInvalid={isInvalid}
+      mb={5}
+    >
       <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
         {label}
       </FormLabel>

--- a/frontend/src/components/common/TextArea.tsx
+++ b/frontend/src/components/common/TextArea.tsx
@@ -3,29 +3,32 @@ import {
   FormControl,
   FormLabel,
   FormErrorMessage,
-  InputProps,
   FormHelperText,
   Textarea,
 } from "@chakra-ui/react";
 import { WarningIcon } from "@chakra-ui/icons";
 
-export interface TextAreaProps extends InputProps {
+export interface TextAreaProps {
+  onChange: (result: string) => void; 
   label?: string;
   placeholder?: string;
   errorMessage?: string;
   helperText?: string;
   isInvalid?: boolean;
+  defaultValue?: string;
   isRequired?: boolean;
 }
 
-export const TextArea: React.FC<TextAreaProps> = ({
+export const TextArea = ({
+  onChange,
   label,
   placeholder,
   errorMessage,
   helperText,
   isInvalid,
-  isRequired,
-}) => {
+  defaultValue="",
+  isRequired=false,
+}: TextAreaProps) => {
   return (
     <FormControl
       id={label}
@@ -36,7 +39,12 @@ export const TextArea: React.FC<TextAreaProps> = ({
       <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
         {label}
       </FormLabel>
-      <Textarea placeholder={placeholder} errorBorderColor="red.600" />
+      <Textarea
+        placeholder={placeholder}
+        errorBorderColor="red.600"
+        defaultValue={defaultValue}
+        onChange={(e) => onChange(e.target.value)}
+      />
       {errorMessage && (
         <FormErrorMessage>
           <WarningIcon mr={2} /> {errorMessage}

--- a/frontend/src/components/common/TextInput.tsx
+++ b/frontend/src/components/common/TextInput.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import {
+  FormControl,
+  FormLabel,
+  FormErrorMessage,
+  Input,
+  InputProps,
+  FormHelperText,
+} from "@chakra-ui/react";
+import { WarningIcon } from "@chakra-ui/icons";
+
+export interface TextInputProps extends InputProps {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  errorMessage?: string;
+  helperText?: string;
+  isInvalid?: boolean;
+}
+
+export const TextInput: React.FC<TextInputProps> = ({
+  name,
+  label,
+  placeholder,
+  errorMessage,
+  helperText,
+  isInvalid,
+}) => {
+  return (
+    <FormControl id={name} isInvalid={isInvalid} mb={5}>
+      <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
+        {label}
+      </FormLabel>
+      <Input type={name} placeholder={placeholder} errorBorderColor="red.600" />
+      {errorMessage && (
+        <FormErrorMessage>
+          <WarningIcon mr={2} /> {errorMessage}
+        </FormErrorMessage>
+      )}
+      {helperText && !isInvalid && (
+        <FormHelperText>{helperText}</FormHelperText>
+      )}
+    </FormControl>
+  );
+};

--- a/frontend/src/components/common/TextInput.tsx
+++ b/frontend/src/components/common/TextInput.tsx
@@ -10,7 +10,6 @@ import {
 import { WarningIcon } from "@chakra-ui/icons";
 
 export interface TextInputProps extends InputProps {
-  name: string;
   label?: string;
   placeholder?: string;
   errorMessage?: string;
@@ -19,7 +18,6 @@ export interface TextInputProps extends InputProps {
 }
 
 export const TextInput: React.FC<TextInputProps> = ({
-  name,
   label,
   placeholder,
   errorMessage,
@@ -27,11 +25,15 @@ export const TextInput: React.FC<TextInputProps> = ({
   isInvalid,
 }) => {
   return (
-    <FormControl id={name} isInvalid={isInvalid} mb={5}>
+    <FormControl id={label} isInvalid={isInvalid} mb={5}>
       <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
         {label}
       </FormLabel>
-      <Input type={name} placeholder={placeholder} errorBorderColor="red.600" />
+      <Input
+        type={label}
+        placeholder={placeholder}
+        errorBorderColor="red.600"
+      />
       {errorMessage && (
         <FormErrorMessage>
           <WarningIcon mr={2} /> {errorMessage}

--- a/frontend/src/components/common/TextInput.tsx
+++ b/frontend/src/components/common/TextInput.tsx
@@ -4,26 +4,31 @@ import {
   FormLabel,
   FormErrorMessage,
   Input,
-  InputProps,
   FormHelperText,
 } from "@chakra-ui/react";
 import { WarningIcon } from "@chakra-ui/icons";
 
-export interface TextInputProps extends InputProps {
+export interface TextInputProps {
+  onChange: (result: string) => void; 
   label?: string;
   placeholder?: string;
   errorMessage?: string;
   helperText?: string;
   isInvalid?: boolean;
+  defaultValue?: string;
+  isRequired?: boolean;
 }
 
-export const TextInput: React.FC<TextInputProps> = ({
+export const TextInput = ({
+  onChange,
   label,
   placeholder,
   errorMessage,
   helperText,
   isInvalid,
-}) => {
+  defaultValue="",
+  isRequired=false,
+}: TextInputProps) => {
   return (
     <FormControl id={label} isInvalid={isInvalid} mb={5}>
       <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
@@ -33,6 +38,9 @@ export const TextInput: React.FC<TextInputProps> = ({
         type={label}
         placeholder={placeholder}
         errorBorderColor="red.600"
+        onChange={(e) => onChange(e.target.value)}
+        defaultValue={defaultValue}
+        isRequired={isRequired}
       />
       {errorMessage && (
         <FormErrorMessage>

--- a/frontend/src/components/pages/ManageCoursesPage.tsx
+++ b/frontend/src/components/pages/ManageCoursesPage.tsx
@@ -1,14 +1,16 @@
 import React from "react";
 import { useQuery } from "@apollo/client";
-import { Box, Button, Flex, Spinner, Text, VStack } from "@chakra-ui/react";
+import { Box, Button, Flex, Spinner, Text, useDisclosure, VStack } from "@chakra-ui/react";
 import { SmallAddIcon } from "@chakra-ui/icons";
 import CoursePreview from "../admin/CoursePreview";
 import { COURSES } from "../../APIClients/queries/CourseQueries";
 import { CourseResponse } from "../../APIClients/types/CourseClientTypes";
 import { AdminPage } from "../../types/AdminDashboardTypes";
 import SideBar from "../admin/SideBar";
+import EditCourseModal from "../admin/EditCourseModal";
 
 const ManageCoursesPage = (): React.ReactElement => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const [courses, setCourses] = React.useState<CourseResponse[] | null>();
 
   const { loading, error } = useQuery<{
@@ -45,7 +47,7 @@ const ManageCoursesPage = (): React.ReactElement => {
           <Text variant="display-lg" pb={6}>
             Courses
           </Text>
-          <Button variant="md" leftIcon={<SmallAddIcon />}>
+          <Button variant="md" leftIcon={<SmallAddIcon />} onClick={onOpen}>
             Create New Course
           </Button>
         </Flex>
@@ -53,6 +55,7 @@ const ManageCoursesPage = (): React.ReactElement => {
           {loading ? <Spinner size="xl" /> : displayCoursePreviews()}
         </VStack>
       </Box>
+      {isOpen && <EditCourseModal isOpen={isOpen} onClose={onClose} />}
     </Flex>
   );
 };

--- a/frontend/src/components/pages/ManageCoursesPage.tsx
+++ b/frontend/src/components/pages/ManageCoursesPage.tsx
@@ -11,21 +11,15 @@ import EditCourseModal from "../admin/EditCourseModal";
 
 const ManageCoursesPage = (): React.ReactElement => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [courses, setCourses] = React.useState<CourseResponse[] | null>();
 
-  const { loading, error } = useQuery<{
-    courses: Array<CourseResponse>;
-  }>(COURSES, {
-    onCompleted: (data) => {
-      setCourses(data.courses);
-    },
-  });
+  const { data, loading, error } = useQuery<{courses: Array<CourseResponse>}>(COURSES);
+  const { courses } = data ?? {courses: []};
 
   const displayCoursePreviews = () => {
-    if (!courses?.length) {
+    if (!courses.length) {
       return <h1>There are no courses.</h1>;
     }
-    return courses?.map((course) => (
+    return courses.map((course) => (
       <CoursePreview key={course.id} course={course} />
     ));
   };

--- a/frontend/src/components/pages/ManageCoursesPage.tsx
+++ b/frontend/src/components/pages/ManageCoursesPage.tsx
@@ -24,14 +24,7 @@ const ManageCoursesPage = (): React.ReactElement => {
       return <h1>There are no courses.</h1>;
     }
     return courses?.map((course) => (
-      <CoursePreview
-        key={course.id}
-        courseId={course.id}
-        title={course.title}
-        description={course.description}
-        isPrivate={course.private}
-        modules={course.modules}
-      />
+      <CoursePreview key={course.id} course={course} />
     ));
   };
 

--- a/frontend/src/types/AdminDashboardTypes.ts
+++ b/frontend/src/types/AdminDashboardTypes.ts
@@ -1,21 +1,4 @@
-import { Module } from "../APIClients/types/CourseClientTypes";
 import { UserResponse } from "../APIClients/types/UserClientTypes";
-
-export interface ModulePreviewProps {
-  index: number;
-  courseId: string;
-  title: string;
-  image: string | null;
-  published: boolean;
-}
-
-export interface CoursePreviewProps {
-  courseId: string;
-  title: string;
-  description: string | null;
-  isPrivate: boolean;
-  modules: Module[] | null;
-}
 
 export enum AdminPage {
   ManageCourses,

--- a/frontend/src/types/ComponentTypes.ts
+++ b/frontend/src/types/ComponentTypes.ts
@@ -1,5 +1,5 @@
 export interface EditActionsKebabMenuProps {
   handleEditDetailsClick: () => void;
-  deleteFunction: () => boolean;
+  deleteFunction: () => void;
   showHorizontal: boolean;
 }


### PR DESCRIPTION
## Implementation Description
Implements landing Page: Modals #64 
Implements modals to edit and create courses and modules, and to confirm deletes of courses/modules. Does not include backend calls to submit forms, or photo uploading for edit module modal.

Components added:
- DeleteModal.tsx: base delete modal (can be reused for different deletion purposes)
- Edit Course/Module Modals: specific modals for editing courses and modules
Common:
- TextInput.tsx: component for user input in forms (based off Chakra UI input)
- TextArea.tsx: component for user input more than one line (based off Chakra UI TextArea)
- SwitchInput.tsx: based off Chakra UI switch
- Modal.tsx: base modal component (based off Chakra UI Modal)

Still needs to be implemented:
- photo uploading for module editing
- error messages and states for when user enters invalid input (ex. empty title)

## Screenshots
![image](https://user-images.githubusercontent.com/41529410/164993895-ffe0e85e-61b5-4058-924f-2040d02b024a.png)
![image](https://user-images.githubusercontent.com/41529410/164993909-6a086d72-26d0-4103-a5c7-5682d00050d2.png)

## What should reviewers focus on?
- Are `useMutation` hooks being used properly?
- is the formatCourseRequest function alright? It's definitely an overloaded function, it might be good to use a reducer to be more explicit

## Testing Procedure
- Try invalid inputs (e.g. no inputs)
- Make sure every edit, delete, and cancel works as intended

## Things to Note
- This refetches the entire COURSES query upon a mutation which is pretty inefficient. Might be worth reconsidering. 

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)