### PR TITLE
Add edit/copy/delete buttons on content block hover

### DIFF
--- a/frontend/src/components/module-editor/EditContentOptionsMenu.tsx
+++ b/frontend/src/components/module-editor/EditContentOptionsMenu.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { HStack, IconButton } from "@chakra-ui/react";
+import { EditIcon, CopyIcon, DeleteIcon } from "@chakra-ui/icons";
+import { EditContentOptionsMenuProps } from "../../types/ModuleEditorTypes";
+
+const EditContentOptionsMenu = ({
+  isVisible,
+  onEditClick,
+  onCopyClick,
+  onDeleteClick,
+}: EditContentOptionsMenuProps): React.ReactElement => {
+  return (
+    <HStack spacing={0} visibility={isVisible ? "visible" : "hidden"}>
+      <IconButton
+        aria-label="Edit this content block"
+        variant="transparent"
+        onClick={onEditClick}
+        m={0}
+        icon={<EditIcon color="background.dark" h={5} w={5} />}
+      />
+      <IconButton
+        aria-label="Duplicate this content block"
+        variant="transparent"
+        onClick={onCopyClick}
+        m={0}
+        icon={<CopyIcon color="background.dark" h={5} w={5} />}
+      />
+      <IconButton
+        aria-label="Delete this content block from lesson"
+        variant="transparent"
+        onClick={onDeleteClick}
+        m={0}
+        icon={<DeleteIcon color="background.dark" h={5} w={5} />}
+      />
+    </HStack>
+  );
+};
+
+export default EditContentOptionsMenu;

--- a/frontend/src/components/module-editor/EditableContentBlock.tsx
+++ b/frontend/src/components/module-editor/EditableContentBlock.tsx
@@ -4,6 +4,7 @@ import { Draggable } from "react-beautiful-dnd";
 
 import { ContentBlock, ContentTypeEnum } from "../../types/ModuleEditorTypes";
 import { TextBlock, ImageBlock } from "../common/content";
+import EditContentOptionsMenu from "./EditContentOptionsMenu";
 
 /* eslint-disable react/jsx-props-no-spreading */
 
@@ -45,7 +46,7 @@ const EditableContentBlock = ({
           style={provided.draggableProps.style}
         >
           <Divider opacity={isHovered ? 1 : 0} />
-          <Flex justify="space-between">
+          <Flex width="100%" justify="space-between">
             <Box opacity={isHovered ? 1 : 0} {...provided.dragHandleProps}>
               <svg width="24" height="24" viewBox="0 0 24 24">
                 <path
@@ -55,6 +56,12 @@ const EditableContentBlock = ({
               </svg>
             </Box>
             {SelectContentBlock(block)}
+            <EditContentOptionsMenu
+              isVisible={isHovered}
+              onEditClick={() => {}}
+              onCopyClick={() => {}}
+              onDeleteClick={() => {}}
+            />
           </Flex>
           <Divider opacity={isHovered ? 1 : 0} />
         </VStack>

--- a/frontend/src/theme/components/button.ts
+++ b/frontend/src/theme/components/button.ts
@@ -121,6 +121,13 @@ const Button = {
       fontSize: "xs",
       height: "32px",
     },
+    transparent: {
+      bg: "transparent",
+      padding: "0px",
+      margin: "0px",
+      border: "0px",
+      fontWeight: "normal",
+    },
   },
   defaultProps: {
     variant: "default",

--- a/frontend/src/types/ModuleEditorTypes.ts
+++ b/frontend/src/types/ModuleEditorTypes.ts
@@ -117,3 +117,10 @@ export type EditorContextAction =
       type: "delete-block";
       value: number;
     };
+
+export interface EditContentOptionsMenuProps {
+  isVisible: boolean;
+  onEditClick: () => void;
+  onCopyClick: () => void;
+  onDeleteClick: () => void;
+}


### PR DESCRIPTION
Note: I'm still unhappy with the padding on the left side (when you hover, you can see that the divider doesn't extend fully to the left, because of the sidebar). Not blocking and high-priority, but little fix TODO. Similar for padding between buttons, it seems to force a width on the icon button

## Implementation Description
- Add icon buttons to each content block, for edit, copy, and delete options
- Dummy buttons right now (not doing anything)

## Screenshots

https://user-images.githubusercontent.com/40974372/169189856-4cd88946-f7de-4ce6-a846-b8a6ad435c28.mov

Compare to [figma](https://www.figma.com/file/Dimm13cjrpYU5LkcrV6VxF/Course-Editor?node-id=691%3A3296):

<img width="1432" alt="Screen Shot 2022-05-18 at 10 25 02 PM" src="https://user-images.githubusercontent.com/40974372/169190926-ba4e8361-39f4-45cd-bb8c-cd5f6e32d3d9.png">
- slight changes to the icons used (used the default Chakra icons)
- check spacing? I matched the Figma but will double check because it looks different

## What should reviewers focus on?
- What's the right approach for adding those "on click" functions for edit / copy / delete? I assumed that we want the funcs to be sent in as props, that way it can edit the "unsaved changes" in the parent component
- Accessibility-wise, is it the right tab index approach? I kept the component as existing with zero opacity (matching the drag+drop operator on left side) so that spacing was same no matter the hover state,  but it means I needed to override the tab index manually

## Testing Procedure
- What test(s) should we run to make sure your code works? manual QA
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

## Things to Note
- Additional dependencies/libraries you've added? nope
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)