### PR TITLE
[RHS-145]: Fix user access to list courses endpoint

### DIFF
--- a/backend/services/implementations/courseService.ts
+++ b/backend/services/implementations/courseService.ts
@@ -51,11 +51,9 @@ class CourseService implements ICourseService {
           [{ $match: queryAttributes }, ...publishedModulesOnlyQuery],
         ).exec();
 
-        if (!courseQueryResult || courseQueryResult.length === 0) {
-          throw new Error(`Course id ${id} not found`);
-        }
-
-        [course] = courseQueryResult;
+        course = courseQueryResult?.length
+          ? MgCourse.hydrate(courseQueryResult[0])
+          : null;
       } else {
         course = await MgCourse.findOne(queryAttributes);
       }
@@ -93,6 +91,7 @@ class CourseService implements ICourseService {
           ...filterQueryObject,
           ...publishedModulesOnlyQuery,
         ]).exec();
+        courses = courses?.map(MgCourse.hydrate.bind(MgCourse)) || null;
       } else {
         courses = await MgCourse.find(
           queryConditions.includePrivateCourses ? {} : { private: false },


### PR DESCRIPTION
## Implementation Description
Details: Depending on whether a user is a User or an Admin, we fetch courses from the DB in different ways. Either we fetch them using find (Admins) or using aggregate (Users). However, results from an aggregation are missing the .id field by default, which causes GraphQL queries which expect that field to fail (see [this issue](https://github.com/Automattic/mongoose/issues/8784)).  To fix this, we can pass the aggregation results through MgCourse.hydrate, which will populate the expected fields.

## Screenshots
N/A

## What should reviewers focus on?
- 

## Testing Procedure
- What test(s) should we run to make sure your code works? Set a user to the "User" role in Mongo, then load the admin homepage `/admin/courses`. If there's no crash, this fix is working.
   - What ways could the input be wrong? N/A
   - Is it secure? Could nefarious users access/break it? See below.

## Things to Note
The fact that "User" users can see the admin page might be seen as a security issue, but since we're packaging both admin and non-admin routes in the same bundle, a nefarious user could see these pages regardless. (Also, the relevant backend routes are already protected by RBAC.) We might consider (in a future ticket) redirecting "User" users away from this page, however, since otherwise they might encounter a worse UX (when random portions of the page don't work due to the backend denying their permission).

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
