### PR TITLE
[RHS-152]: Fix `isRequired` field behaviour for `TextInput` component

### DIFF
--- a/frontend/src/components/common/TextInput.tsx
+++ b/frontend/src/components/common/TextInput.tsx
@@ -30,7 +30,12 @@ export const TextInput = ({
   isRequired = false,
 }: TextInputProps): React.ReactElement => {
   return (
-    <FormControl id={label} isInvalid={isInvalid} mb={5}>
+    <FormControl
+      id={label}
+      isRequired={isRequired}
+      isInvalid={isInvalid}
+      mb={5}
+    >
       <FormLabel fontWeight={400} color={isInvalid ? "red.500" : "blackAlpha"}>
         {label}
       </FormLabel>
@@ -40,7 +45,6 @@ export const TextInput = ({
         errorBorderColor="red.600"
         onChange={(e) => onChange(e.target.value)}
         defaultValue={defaultValue}
-        isRequired={isRequired}
       />
       {errorMessage && (
         <FormErrorMessage>


### PR DESCRIPTION
## Implementation Description
The `isRequired` prop within the `TextInput` component was being passed into the wrong child component, causing the component to not properly display its required status. This PR fixes the issue.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/9922514/171316949-3bb64ba1-bb08-4743-81ee-1ca3ede77c93.png)

After:
![image](https://user-images.githubusercontent.com/9922514/171316803-92576baf-39c8-48e3-8c7b-ca358bc150fb.png)

## What should reviewers focus on?

## Testing Procedure
Visually inspect.

## Things to Note
N/A

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
