### PR TITLE
[RHS-158]: Add linter pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 **/*.cache
 **/*.egg-info
 .history/
+.eslintcache

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+-   repo: local
+    hooks:
+    -   id: felint
+        name: Lint frontend files
+        files: ^frontend/.*\.[jt]sx?$
+        types: [file]
+        language: system
+        entry: ./scripts/lint.sh felint
+    -   id: belint
+        name: Lint backend files
+        files: ^backend/.*\.[jt]sx?$
+        types: [file]
+        language: system
+        entry: ./scripts/lint.sh belint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       context: ./frontend
       dockerfile: Dockerfile
     volumes:
+      - ./scripts/launch_dev.sh:/.dev/launch_dev.sh
+      - ./.git/hooks:/.dev/git-hooks
       - ./frontend:/app
       - /app/node_modules
     ports:
@@ -15,12 +17,21 @@ services:
       - CHOKIDAR_USEPOLLING=true
     env_file:
       - ./frontend/.env
+    entrypoint:
+      - /bin/bash
+      - /.dev/launch_dev.sh
+      - -p
+      - /.dev/git-hooks
+      - yarn
+      - start
   ts-backend:
     container_name: RHS-backend
     build:
       context: ./backend
       dockerfile: Dockerfile
     volumes:
+      - ./scripts/launch_dev.sh:/.dev/launch_dev.sh
+      - ./.git/hooks:/.dev/git-hooks
       - ./backend:/app
       - /app/node_modules
     ports:
@@ -30,3 +41,10 @@ services:
       - 8.8.8.8
     env_file:
       - ./.env
+    entrypoint:
+      - /bin/bash
+      - /.dev/launch_dev.sh
+      - -p
+      - /.dev/git-hooks
+      - yarn
+      - dev

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,8 +51,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
-    "fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix"
+    "lint": "eslint . --ext .ts,.tsx,.js,.jsx --cache",
+    "fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix --cache"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/launch_dev.sh
+++ b/scripts/launch_dev.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+HOOK_PATH=".git/hooks"
+if [ "$1" == "-p" ]; then
+    HOOK_PATH="$2"
+    shift 2
+fi
+PRECOMMIT_PATH="$HOOK_PATH/pre-commit"
+
+if ! [ -f "$PRECOMMIT_PATH" ] || ! grep "exec pre-commit" "$PRECOMMIT_PATH" > /dev/null; then
+    echo "Pre-commit hooks not installed!" >&2
+    echo "Please install \`pre-commit\`: https://pre-commit.com/#install" >&2
+    echo "Once installed, run \`pre-commit install\` from this repository and try again." >&2
+    exit 1
+fi
+
+exec "$@"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+# https://stackoverflow.com/a/32981392/3761440
+faketty () {
+    script -qefc "$(printf "%q " "$@")" /dev/null
+}
+
+
+CONTAINER_NAME=
+SERVICE_NAME=
+if [[ "$1" = "belint" ]]; then
+    CONTAINER_NAME=RHS-backend
+    SERVICE_NAME=ts-backend
+elif [[ "$1" = "felint" ]]; then
+    CONTAINER_NAME=RHS-frontend
+    SERVICE_NAME=frontend
+else
+    echo "Unknown lint command \"$1\", must be one of: felint, belint" >&2
+    exit 1
+fi
+
+if [ "$(docker ps --filter name=$CONTAINER_NAME -q)" ]; then
+    docker exec -t $CONTAINER_NAME yarn fix
+    exit
+fi
+
+echo "Warning: Docker services not running! Linting will be slow." >&2
+echo "Run \`docker-compose up\` to speed this up." >&2
+
+faketty docker-compose run -t --rm --entrypoint yarn $SERVICE_NAME fix

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -29,4 +29,4 @@ fi
 echo "Warning: Docker services not running! Linting will be slow." >&2
 echo "Run \`docker-compose up\` to speed this up." >&2
 
-faketty docker-compose run -t --rm --entrypoint yarn $SERVICE_NAME fix
+faketty docker-compose run --rm --entrypoint yarn $SERVICE_NAME fix

--- a/utils.sh
+++ b/utils.sh
@@ -1,7 +1,1 @@
-if [[ "$1" = "belint" ]]
-then
-    docker exec -it RHS-backend /bin/bash -c "yarn lint --fix"
-elif [[ "$1" = "felint" ]]
-then
-    docker exec -it RHS-frontend /bin/bash -c "yarn lint --fix"
-fi
+scripts/lint.sh


### PR DESCRIPTION
## Implementation Description
- Hint at devs to install pre-commit on docker startup
- Lint on pre-commit
- Use linter cache to speed up pre-commit hooks

## Screenshots
![image](https://user-images.githubusercontent.com/9922514/171528252-94941b18-2149-4836-b9d9-e462eede4082.png)

## What should reviewers focus on?
- Can you think of cleaner/faster ways to implement this?

## Testing Procedure
- Is it secure? Could nefarious users access/break it?
A: Not designed to be secure, only hint to install pre-commit hooks for users.

## Things to Note

## Checklist
- [x] Ensure code follows style guide by running the linters (:D)
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
