### PR TITLE
[RHS-173]: Enable debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 **/*.log
 **/firebaseServiceAccount.json
 **/.DS_Store
-.vscode
+.vscode/**/*
+!.vscode/launch.json
 **/*.cache
 **/*.egg-info
 .history/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug: Frontend",
+            "type": "pwa-chrome",
+            "request": "launch",
+            "url": "http://localhost:3000",
+            "webRoot": "${workspaceFolder}/frontend",
+            "sourceMapPathOverrides": {
+                "/app/*": "${webRoot}/*"
+            }
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Debug: Backend",
+            "localRoot": "${workspaceFolder}/backend",
+            "remoteRoot": "/app"
+        }
+    ]
+}

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -1,4 +1,4 @@
 {
     "ext": "ts,js,json",
-    "exec": "ts-node -r dotenv/config server"
+    "exec": "node -r dotenv/config  -r ts-node/register --inspect=0.0.0.0:9229 server"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       - /app/node_modules
     ports:
       - 5000:5000
+      - 9229:9229  # debugging
     dns:
       - 8.8.8.8
     env_file:
       - ./.env
-


### PR DESCRIPTION
## Implementation Description
A feature for the development environment requested by devs was to be able to connect to the frontend/backend via a debugger. This PR adds some configuration to the repository to support this.
- [RHS-173]: Enable debug mode for node while developing
- [RHS-173]: Add launch configurations for devs using VS Code

## Screenshots
N/A

## What should reviewers focus on?
- How do you feel about permanently running in `--inspect` mode for all local development? Is it worth it in order to prevent having to commit a `settings.json` with extra command configuration?

## Testing Procedure
Feel free to check this out locally and try it yourself. The normal development flow is unchanged (run `docker-compose up --build`), but you should be able to run additional debug configurations from the tab on the left-hand side of VS Code.

## Things to Note
N/A

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
