### PR TITLE
Editor content edit buttons should be top aligned

### DIFF
--- a/frontend/src/components/module-editor/EditContentOptionsMenu.tsx
+++ b/frontend/src/components/module-editor/EditContentOptionsMenu.tsx
@@ -10,7 +10,11 @@ const EditContentOptionsMenu = ({
   onDeleteClick,
 }: EditContentOptionsMenuProps): React.ReactElement => {
   return (
-    <HStack spacing={0} visibility={isVisible ? "visible" : "hidden"}>
+    <HStack
+      spacing={0}
+      visibility={isVisible ? "visible" : "hidden"}
+      align="start"
+    >
       <IconButton
         aria-label="Edit this content block"
         variant="transparent"


### PR DESCRIPTION
## Implementation Description
As the title says, per designer feedback, the content edit/delete buttons in the module editor should be top-aligned rather than centre-aligned.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/9922514/173720206-cf41a52a-8a9a-40bf-b651-cc1acb4a3cb2.png)

After:
![image](https://user-images.githubusercontent.com/9922514/173720187-5f4c3091-e5ce-4d60-9028-c1fa4467957d.png)

## What should reviewers focus on?

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
