### PR TITLE
Content block modals

### DIFF
--- a/frontend/src/components/admin/EditTextModal.tsx
+++ b/frontend/src/components/admin/EditTextModal.tsx
@@ -27,16 +27,24 @@ const EditTextModal = ({
   const { state, dispatch } = context;
 
   const onSave = () => {
-    const newBlock = block;
-    newBlock.content.text = text;
+    const newBlock = {
+      ...block,
+      content: {
+        ...block.content,
+        text,
+      }
+    };
+    // newBlock.content.text = text;
     dispatch({
       type: "update-block",
       value: {
         index,
-        block,
+        block: newBlock,
       },
     });
-  }
+    // state.
+    onClose();
+  };
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/frontend/src/components/admin/EditTextModal.tsx
+++ b/frontend/src/components/admin/EditTextModal.tsx
@@ -1,0 +1,59 @@
+import { Flex, VStack, Image } from "@chakra-ui/react";
+import React, { useContext, useState } from "react";
+
+import { TextInput } from "../common/TextInput";
+import { Modal } from "../common/Modal";
+import { ContentBlock, ContentTypeEnum, EditorContextAction } from "../../types/ModuleEditorTypes";
+import EditorContext from "../../contexts/ModuleEditorContext";
+import { TextArea } from "../common/TextArea";
+
+export interface EditTextModalProps {
+  onClose: () => void;
+  isOpen: boolean;
+  block: ContentBlock;
+  index: number;
+}
+
+const EditTextModal = ({
+  block,
+  index,
+  isOpen,
+  onClose,
+}: EditTextModalProps): React.ReactElement => {
+  const context = useContext(EditorContext);
+  const [text, setText] = useState(block.content.text ?? "");
+
+  if (!context) return <></>;
+  const { state, dispatch } = context;
+
+  const onSave = () => {
+    const newBlock = block;
+    newBlock.content.text = text;
+    dispatch({
+      type: "update-block",
+      value: {
+        index,
+        block,
+      },
+    });
+  }
+
+  return (
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    <Modal
+      size="xl"
+      header="Edit Text Component"
+      onConfirm={onSave}
+      onCancel={onClose}
+      isOpen={isOpen}
+    >
+      <Flex>
+        <VStack flex="1">
+          <TextArea defaultValue={text} onChange={setText} isRequired />
+        </VStack>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default EditTextModal;

--- a/frontend/src/components/admin/EditTextModal.tsx
+++ b/frontend/src/components/admin/EditTextModal.tsx
@@ -1,10 +1,16 @@
 import { Flex, VStack, Image } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
+import {
+  EditorChangeStatuses,
+  EditorContextType,
+  ModuleEditorParams,
 
+  ContentBlock,
+
+} from "../../types/ModuleEditorTypes";
 import { TextInput } from "../common/TextInput";
 import { Modal } from "../common/Modal";
-import { ContentBlock, ContentTypeEnum, EditorContextAction } from "../../types/ModuleEditorTypes";
-import EditorContext from "../../contexts/ModuleEditorContext";
+
 import { TextArea } from "../common/TextArea";
 
 export interface EditTextModalProps {
@@ -12,6 +18,7 @@ export interface EditTextModalProps {
   isOpen: boolean;
   block: ContentBlock;
   index: number;
+  context: EditorContextType;
 }
 
 const EditTextModal = ({
@@ -19,8 +26,9 @@ const EditTextModal = ({
   index,
   isOpen,
   onClose,
-}: EditTextModalProps): React.ReactElement => {
-  const context = useContext(EditorContext);
+  context,
+}:
+EditTextModalProps): React.ReactElement => {
   const [text, setText] = useState(block.content.text ?? "");
 
   if (!context) return <></>;
@@ -32,9 +40,9 @@ const EditTextModal = ({
       content: {
         ...block.content,
         text,
-      }
+      },
     };
-    // newBlock.content.text = text;
+
     dispatch({
       type: "update-block",
       value: {
@@ -42,7 +50,7 @@ const EditTextModal = ({
         block: newBlock,
       },
     });
-    // state.
+  
     onClose();
   };
 

--- a/frontend/src/components/module-editor/EditableContentBlock.tsx
+++ b/frontend/src/components/module-editor/EditableContentBlock.tsx
@@ -1,13 +1,17 @@
 import { Box, Divider, Flex, useDisclosure, VStack } from "@chakra-ui/react";
-import React, { useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { Draggable } from "react-beautiful-dnd";
 
-import { ContentBlock, ContentTypeEnum } from "../../types/ModuleEditorTypes";
+import { ContentBlock, ContentTypeEnum ,
+  EditorContextType,
+} from "../../types/ModuleEditorTypes";
 import { TextBlock, ImageBlock } from "../common/content";
 import EditContentOptionsMenu from "./EditContentOptionsMenu";
 
 import { ReactComponent as DragHandleIconSvg } from "../../assets/DragHandle.svg";
 import EditTextModal from "../admin/EditTextModal";
+import EditorContext from "../../contexts/ModuleEditorContext";
+
 /* eslint-disable react/jsx-props-no-spreading */
 
 const SelectContentBlock = (block: ContentBlock): React.ReactElement => {
@@ -28,9 +32,11 @@ const SelectContentBlock = (block: ContentBlock): React.ReactElement => {
 const EditableContentBlock = ({
   block,
   index,
+  context,
 }: {
   block: ContentBlock;
   index: number;
+  context: EditorContextType;
 }): React.ReactElement => {
   const [isHovered, setIsHovered] = useState(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -69,6 +75,7 @@ const EditableContentBlock = ({
             onClose={onClose}
             block={block}
             index={index}
+            context={context}
           />
         </VStack>
       )}

--- a/frontend/src/components/module-editor/EditableContentBlock.tsx
+++ b/frontend/src/components/module-editor/EditableContentBlock.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, VStack } from "@chakra-ui/react";
+import { Box, Divider, Flex, useDisclosure, VStack } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { Draggable } from "react-beautiful-dnd";
 
@@ -7,6 +7,7 @@ import { TextBlock, ImageBlock } from "../common/content";
 import EditContentOptionsMenu from "./EditContentOptionsMenu";
 
 import { ReactComponent as DragHandleIconSvg } from "../../assets/DragHandle.svg";
+import EditTextModal from "../admin/EditTextModal";
 /* eslint-disable react/jsx-props-no-spreading */
 
 const SelectContentBlock = (block: ContentBlock): React.ReactElement => {
@@ -32,6 +33,7 @@ const EditableContentBlock = ({
   index: number;
 }): React.ReactElement => {
   const [isHovered, setIsHovered] = useState(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Draggable key={block.id} draggableId={block.id} index={index}>
@@ -54,12 +56,20 @@ const EditableContentBlock = ({
             {SelectContentBlock(block)}
             <EditContentOptionsMenu
               isVisible={isHovered}
-              onEditClick={() => {}}
+              onEditClick={() => {
+                onOpen();
+              }}
               onCopyClick={() => {}}
               onDeleteClick={() => {}}
             />
           </Flex>
           <Divider opacity={isHovered ? 1 : 0} />
+          <EditTextModal
+            isOpen={isOpen}
+            onClose={onClose}
+            block={block}
+            index={index}
+          />
         </VStack>
       )}
     </Draggable>

--- a/frontend/src/components/module-editor/LessonViewer.tsx
+++ b/frontend/src/components/module-editor/LessonViewer.tsx
@@ -20,7 +20,12 @@ const LessonViewer = (): React.ReactElement => {
         {(provided) => (
           <Flex ref={provided.innerRef} direction="column" flex="1">
             {lesson?.content.map((block, index) => (
-              <EditableContentBlock block={block} key={index} index={index} />
+              <EditableContentBlock
+                block={block}
+                key={index}
+                index={index}
+                context={context}
+              />
             ))}
             {provided.placeholder}
           </Flex>

--- a/frontend/src/reducers/ModuleEditorContextReducer.ts
+++ b/frontend/src/reducers/ModuleEditorContextReducer.ts
@@ -195,14 +195,13 @@ const updateLessonContentBlock = (
   block: ContentBlock,
 ): EditorStateType => {
   const id = state.focusedLesson;
-  if (!id || Object.keys(state.lessons).includes(id)) return state;
+  if (!id || !Object.keys(state.lessons).includes(id)) return state;
 
   console.assert(index >= 0, "Content block index must be positive");
   console.assert(
     index < state.lessons[id].content.length,
     "Content block index exceeds content length",
   );
-
   const newState = { ...state };
   newState.lessons[id].content[index] = block;
   // Update to let the state know things have changed
@@ -267,6 +266,7 @@ export default function EditorContextReducer(
         action.value.newIndex,
       );
     case "update-block":
+      console.log("CALLED");
       return updateLessonContentBlock(
         state,
         action.value.index,


### PR DESCRIPTION
## Implementation Description
Implements #112. 
Created an edit text modal that allows users to update text content blocks using the `update-lesson` action. The content block should update properly and allow users to save their changes afterwards.

## Screenshots
<img width="917" alt="image" src="https://user-images.githubusercontent.com/55213953/173724548-810a9c36-76ed-4f8b-9d7f-b39784029cfd.png">


## What should reviewers focus on?
- 

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [ ] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)