### PR TITLE
[RHS-179] : Prevent Users from Changing their Role

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 db-init/create-multiple-dbs.sh eol=lf
+scripts/* eol=lf

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -54,8 +54,13 @@ const executableSchema = makeExecutableSchema({
 const authorizedByAllRoles = () =>
   isAuthorizedByRole(new Set(["User", "Admin", "Staff"]));
 const authorizedByAdmin = () => isAuthorizedByRole(new Set(["Admin"]));
-const authorizeRoleChange = (id: string) => { return and(isAuthorizedToChangeRole(id), isAuthorizedByRole(new Set(["Admin"])))};
-//and(isAuthorizedToChangeRole(id), isAuthorizedByRole(new Set(["Admin"])))
+const authorizeRoleChange = (id: string) => {
+  return and(
+    isAuthorizedToChangeRole(id),
+    isAuthorizedByRole(new Set(["Admin"])),
+  );
+};
+// and(isAuthorizedToChangeRole(id), isAuthorizedByRole(new Set(["Admin"])))
 
 const graphQLMiddlewares = {
   Query: {

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -60,7 +60,6 @@ const authorizeRoleChange = (id: string) => {
     isAuthorizedByRole(new Set(["Admin"])),
   );
 };
-// and(isAuthorizedToChangeRole(id), isAuthorizedByRole(new Set(["Admin"])))
 
 const graphQLMiddlewares = {
   Query: {

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -6,6 +6,8 @@ import {
   isAuthorizedByEmail,
   isAuthorizedByRole,
   isAuthorizedByUserId,
+  isAuthorizedToChangeRole,
+  and,
 } from "../middlewares/auth";
 import authResolvers from "./resolvers/authResolvers";
 import authType from "./types/authType";
@@ -52,6 +54,8 @@ const executableSchema = makeExecutableSchema({
 const authorizedByAllRoles = () =>
   isAuthorizedByRole(new Set(["User", "Admin", "Staff"]));
 const authorizedByAdmin = () => isAuthorizedByRole(new Set(["Admin"]));
+const authorizeRoleChange = (id: string) => { return and(isAuthorizedToChangeRole(id), isAuthorizedByRole(new Set(["Admin"])))};
+//and(isAuthorizedToChangeRole(id), isAuthorizedByRole(new Set(["Admin"])))
 
 const graphQLMiddlewares = {
   Query: {
@@ -75,7 +79,7 @@ const graphQLMiddlewares = {
     deleteEntity: authorizedByAllRoles(),
     createUser: authorizedByAdmin(),
     updateUser: authorizedByAdmin(),
-    updateUserRole: authorizedByAdmin(),
+    updateUserRole: authorizeRoleChange("id"),
     deleteUserById: authorizedByAdmin(),
     deleteUserByEmail: authorizedByAdmin(),
     logout: isAuthorizedByUserId("userId"),

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -6,7 +6,7 @@ import {
   isAuthorizedByEmail,
   isAuthorizedByRole,
   isAuthorizedByUserId,
-  iDNotSameasActiveUser,
+  idNotSameAsActiveUser,
 } from "../middlewares/auth";
 import and from "../middlewares/utils/combinatorsUtils";
 import authResolvers from "./resolvers/authResolvers";
@@ -55,7 +55,7 @@ const authorizedByAllRoles = () =>
   isAuthorizedByRole(new Set(["User", "Admin", "Staff"]));
 const authorizedByAdmin = () => isAuthorizedByRole(new Set(["Admin"]));
 const authorizeRoleChange = (id: string) => {
-  return and(authorizedByAdmin(), iDNotSameasActiveUser(id));
+  return and(authorizedByAdmin(), idNotSameAsActiveUser(id));
 };
 
 const graphQLMiddlewares = {

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -6,9 +6,9 @@ import {
   isAuthorizedByEmail,
   isAuthorizedByRole,
   isAuthorizedByUserId,
-  isAuthorizedToChangeRole,
-  and,
+  iDNotSameasActiveUser,
 } from "../middlewares/auth";
+import and from "../middlewares/utils/combinatorsUtils";
 import authResolvers from "./resolvers/authResolvers";
 import authType from "./types/authType";
 import courseResolvers from "./resolvers/courseResolvers";
@@ -55,10 +55,7 @@ const authorizedByAllRoles = () =>
   isAuthorizedByRole(new Set(["User", "Admin", "Staff"]));
 const authorizedByAdmin = () => isAuthorizedByRole(new Set(["Admin"]));
 const authorizeRoleChange = (id: string) => {
-  return and(
-    isAuthorizedToChangeRole(id),
-    isAuthorizedByRole(new Set(["Admin"])),
-  );
+  return and(authorizedByAdmin(), iDNotSameasActiveUser(id));
 };
 
 const graphQLMiddlewares = {

--- a/backend/middlewares/auth.ts
+++ b/backend/middlewares/auth.ts
@@ -26,7 +26,7 @@ logged in user.
  * Note: userIdField is the name of the request parameter containing the requested userId */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-export const iDNotSameasActiveUser = (userIdField: string) => {
+export const idNotSameAsActiveUser = (userIdField: string) => {
   return async (
     resolve: (
       parent: any,
@@ -42,7 +42,7 @@ export const iDNotSameasActiveUser = (userIdField: string) => {
     const accessToken = getAccessToken(context.req);
     const authorized =
       accessToken &&
-      (await authService.iDNotSameasActiveUser(accessToken, args[userIdField]));
+      (await authService.idNotSameAsActiveUser(accessToken, args[userIdField]));
 
     if (!authorized) {
       throw new AuthenticationError("User ID cannot change its own role");

--- a/backend/middlewares/utils/combinatorsUtils.ts
+++ b/backend/middlewares/utils/combinatorsUtils.ts
@@ -1,0 +1,47 @@
+import { GraphQLResolveInfo } from "graphql";
+import { ExpressContext } from "apollo-server-express";
+import { IMiddlewareFunction } from "graphql-middleware";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export type Resolve = (
+  parent: any,
+  args: { [key: string]: any },
+  context: ExpressContext | undefined,
+  info: GraphQLResolveInfo | undefined,
+) => any;
+
+export const callResolver = async (
+  resolver: IMiddlewareFunction<any, ExpressContext>,
+  resolve: Resolve,
+  parent: any,
+  args: { [key: string]: any },
+  context: ExpressContext,
+  info: GraphQLResolveInfo,
+  // eslint-disable-next-line consistent-return
+): Promise<IMiddlewareFunction<any, ExpressContext, any> | undefined> => {
+  if ("resolve" in resolver) {
+    return resolver.resolve?.(resolve, parent, args, context, info);
+  }
+  if (typeof resolver === "function") {
+    return resolver(resolve, parent, args, context, info);
+  }
+};
+
+// Combine two middleware functions and returns their result
+export default function and(
+  firstFn: IMiddlewareFunction<any, ExpressContext>,
+  secondFn: IMiddlewareFunction<any, ExpressContext>,
+): IMiddlewareFunction<any, ExpressContext> {
+  return async (
+    resolve: Resolve,
+    parent: any,
+    args: { [key: string]: any },
+    context: ExpressContext,
+    info: GraphQLResolveInfo,
+  ) => {
+    const resolveFirst = async () => {
+      return callResolver(secondFn, resolve, parent, args, context, info);
+    };
+    return callResolver(firstFn, resolveFirst, parent, args, context, info);
+  };
+}

--- a/backend/middlewares/utils/combinatorsUtils.ts
+++ b/backend/middlewares/utils/combinatorsUtils.ts
@@ -13,6 +13,7 @@ export type Resolve = (
 export const callResolver = async (
   resolver: IMiddlewareFunction<any, ExpressContext>,
   resolve: Resolve,
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   parent: any,
   args: { [key: string]: any },
   context: ExpressContext,

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -163,7 +163,7 @@ class AuthService implements IAuthService {
     }
   }
 
-  async iDNotSameasActiveUser(
+  async idNotSameAsActiveUser(
     accessToken: string,
     requestedUserId: string,
   ): Promise<boolean> {

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -163,6 +163,30 @@ class AuthService implements IAuthService {
     }
   }
 
+  async isAuthorizedToChangeRole(
+    accessToken: string,
+    requestedUserId: string,
+  ): Promise<boolean> {
+    try {
+      const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
+        .auth()
+        .verifyIdToken(accessToken, true);
+      const tokenUserId = await this.userService.getUserIdByAuthId(
+        decodedIdToken.uid,
+      );
+
+      const firebaseUser = await firebaseAdmin
+        .auth()
+        .getUser(decodedIdToken.uid);
+
+      return (
+        firebaseUser.emailVerified && String(tokenUserId) !== requestedUserId
+      );
+    } catch (error) {
+      return false;
+    }
+  }
+
   async isAuthorizedByUserId(
     accessToken: string,
     requestedUserId: string,

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -163,7 +163,7 @@ class AuthService implements IAuthService {
     }
   }
 
-  async isAuthorizedToChangeRole(
+  async iDNotSameasActiveUser(
     accessToken: string,
     requestedUserId: string,
   ): Promise<boolean> {
@@ -174,14 +174,7 @@ class AuthService implements IAuthService {
       const tokenUserId = await this.userService.getUserIdByAuthId(
         decodedIdToken.uid,
       );
-
-      const firebaseUser = await firebaseAdmin
-        .auth()
-        .getUser(decodedIdToken.uid);
-
-      return (
-        firebaseUser.emailVerified && String(tokenUserId) !== requestedUserId
-      );
+      return String(tokenUserId) !== requestedUserId;
     } catch (error) {
       return false;
     }

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -43,14 +43,17 @@ interface IAuthService {
   sendEmailVerificationLink(email: string): Promise<void>;
 
   /**
-   * Determine if the provided access token is valid and authorized to change 
+   * Determine if the provided access token is valid and authorized to change
    * the user role
    * @param accessToken user's access token
-   * @param requestedUserId user's id 
+   * @param requestedUserId user's id
    * @returns true if token is valid and authorized; and if the id does not match
    * current logged in user's id, false otherwise
    */
-   isAuthorizedToChangeRole(accessToken: string, requestedUserId: string,): Promise<boolean>;
+  isAuthorizedToChangeRole(
+    accessToken: string,
+    requestedUserId: string,
+  ): Promise<boolean>;
 
   /**
    * Determine if the provided access token is valid and authorized for at least

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -50,7 +50,7 @@ interface IAuthService {
    * @returns true if token is valid and authorized; and if the id does not match
    * current logged in user's id, false otherwise
    */
-  isAuthorizedToChangeRole(
+  iDNotSameasActiveUser(
     accessToken: string,
     requestedUserId: string,
   ): Promise<boolean>;

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -50,7 +50,7 @@ interface IAuthService {
    * @returns true if token is valid and authorized; and if the id does not match
    * current logged in user's id, false otherwise
    */
-  iDNotSameasActiveUser(
+  idNotSameAsActiveUser(
     accessToken: string,
     requestedUserId: string,
   ): Promise<boolean>;

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -43,6 +43,16 @@ interface IAuthService {
   sendEmailVerificationLink(email: string): Promise<void>;
 
   /**
+   * Determine if the provided access token is valid and authorized to change 
+   * the user role
+   * @param accessToken user's access token
+   * @param requestedUserId user's id 
+   * @returns true if token is valid and authorized; and if the id does not match
+   * current logged in user's id, false otherwise
+   */
+   isAuthorizedToChangeRole(accessToken: string, requestedUserId: string,): Promise<boolean>;
+
+  /**
    * Determine if the provided access token is valid and authorized for at least
    * one of the specified roles
    * @param accessToken user's access token

--- a/frontend/src/components/admin/UserCard.tsx
+++ b/frontend/src/components/admin/UserCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import {
   Button,
   Flex,
@@ -14,6 +14,7 @@ import SelectInput from "../common/SelectInput";
 import UPDATE_USER_ROLE from "../../APIClients/mutations/UserMutations";
 import USER_ROLES from "../../constants/UserConstants";
 import { Role } from "../../types/AuthTypes";
+import AuthContext from "../../contexts/AuthContext";
 
 interface DefaultUserIconProps {
   initials: string;
@@ -52,6 +53,7 @@ const UserCard = ({
 }: UserCardProps): React.ReactElement => {
   const [selectValue, setSelectValue] = useState<Role>(role);
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const { authenticatedUser } = useContext(AuthContext);
 
   useEffect(() => {
     setSelectValue(role);
@@ -100,9 +102,11 @@ const UserCard = ({
     >
       <VStack align="center" spacing={8} ml="60px" mr="132px">
         <DefaultUserIcon initials={getInitials(firstName, lastName)} />
-        <Button onClick={onOpen} variant="outline-md">
-          Edit Role
-        </Button>
+        {authenticatedUser?.email !== email && (
+          <Button onClick={onOpen} variant="outline-md">
+            Edit Role
+          </Button>
+        )}
         <Modal
           header="Edit user role"
           isOpen={isOpen}


### PR DESCRIPTION
## Implementation Description
A follow-up to https://github.com/uwblueprint/rowan-house/issues/136. A logged-in user should not be able to change their own role. There is a frontend and backend implementation to this ticket. The frontend implementation ensures that the edit role button in the `Manage Users` page does not appear when the logged-in user is searched for. The backend implementation acts as a sanity check to ensure a similar functionality. 

## Screenshots
<img width="960" alt="image" src="https://user-images.githubusercontent.com/63923219/176985229-b829f2b9-fcd2-43b4-b9b0-702d6bc38478.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/63923219/176985246-df026ba3-6ab5-4ac3-a5ee-f46ca5a84bec.png">

## What should reviewers focus on?
- Ensure that if a logged-in user searches their name on the  Manage Users page, the edit button does not appear in the user card that appears on the page.
- Logged-in admin users should be able to change the user role of other users on the application. 

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

## Things to Note
- Additional dependencies/libraries you've added? N/A
- Things you'd want to know when coming back to the code after a few months N/A

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [ ] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)