### PR TITLE
[RHS-149]: User -> Learner migration

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -52,7 +52,7 @@ const executableSchema = makeExecutableSchema({
 });
 
 const authorizedByAllRoles = () =>
-  isAuthorizedByRole(new Set(["User", "Admin", "Staff"]));
+  isAuthorizedByRole(new Set(["Learner", "Admin", "Staff"]));
 const authorizedByAdmin = () => isAuthorizedByRole(new Set(["Admin"]));
 const authorizeRoleChange = (id: string) => {
   return and(authorizedByAdmin(), idNotSameAsActiveUser(id));

--- a/backend/graphql/resolvers/authResolvers.ts
+++ b/backend/graphql/resolvers/authResolvers.ts
@@ -41,7 +41,7 @@ const authResolvers = {
       { res }: { res: Response },
     ): Promise<Omit<AuthDTO, "refreshToken">> => {
       const role: Role =
-        process.env.NODE_ENV === "production" ? "User" : "Admin";
+        process.env.NODE_ENV === "production" ? "Learner" : "Admin";
       await userService.createUser({ ...user, role });
       const authDTO = await authService.generateToken(
         user.email,

--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -27,7 +27,7 @@ const getCourseVisibilityAttributes = (
   role: Role,
 ): CourseVisibilityAttributes => {
   switch (role) {
-    case "User":
+    case "Learner":
       return {
         includePrivateCourses: false,
         includeOnlyPublishedModules: true,

--- a/backend/models/user.model.ts
+++ b/backend/models/user.model.ts
@@ -27,7 +27,7 @@ const UserSchema: Schema = new Schema({
   role: {
     type: String,
     required: true,
-    enum: ["User", "Admin", "Staff"],
+    enum: ["Learner", "Admin", "Staff"],
   },
   town: {
     type: String,

--- a/backend/services/implementations/__tests__/userService.test.ts
+++ b/backend/services/implementations/__tests__/userService.test.ts
@@ -16,7 +16,7 @@ const testUsers = [
     firstName: "Wendy",
     lastName: "Darling",
     authId: "321",
-    role: "User",
+    role: "Learner",
   },
   {
     firstName: "Tinker",

--- a/backend/services/implementations/userService.ts
+++ b/backend/services/implementations/userService.ts
@@ -96,7 +96,7 @@ class UserService implements IUserService {
 
     try {
       firebaseUser = await firebaseAdmin.auth().getUserByEmail(email);
-      user = await MgUser.findOne({ authId: firebaseUser.uid });
+      user = await getMongoUserByAuthId(firebaseUser.uid);
 
       if (!user) {
         throw new Error(`userId with authId ${firebaseUser.uid} not found.`);

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -1,4 +1,4 @@
-export type Role = "User" | "Admin" | "Staff";
+export type Role = "Learner" | "Admin" | "Staff";
 
 export type ContentType = "text" | "image" | "video";
 export interface ContentBlock {

--- a/e2e-tests/test_auth.py
+++ b/e2e-tests/test_auth.py
@@ -9,7 +9,7 @@ def register_user(backend_url, body, access_token_field):
     assert response.status_code == 200
     data = response.json()
     assert "role" in data
-    assert data["role"] == "User"
+    assert data["role"] == "Learner"
     assert "id" in data
     assert access_token_field in data
     expected = {k: v for k, v in body.items() if k != "password"}

--- a/e2e-tests/test_auth_gql.py
+++ b/e2e-tests/test_auth_gql.py
@@ -25,7 +25,7 @@ def register_user(backend_url, body, access_token_field):
     assert "register" in response.json()["data"]
     data = response.json()["data"]["register"]
     assert "role" in data
-    assert data["role"] == "User"
+    assert data["role"] == "Learner"
     assert "id" in data
     assert access_token_field in data
     expected = {k: v for k, v in body.items() if k != "password"}

--- a/e2e-tests/test_user.py
+++ b/e2e-tests/test_user.py
@@ -80,14 +80,14 @@ def test_users(backend_url, auth_header, lang, api, new_user_email):
     body1 = {
         "firstName": "Test",
         "lastName": "Script",
-        "role": "User",
+        "role": "Learner",
         "email": new_user_email,
         "password": "password",
     }
     body2 = {
         "firstName": "Test2",
         "lastName": "Script2",
-        "role": "User",
+        "role": "Learner",
         "email": new_user_email,
     }
     if lang != "ts":

--- a/e2e-tests/test_user_gql.py
+++ b/e2e-tests/test_user_gql.py
@@ -142,14 +142,14 @@ def test_users_gql(backend_url, auth_header, lang, api, new_user_email):
     body1 = {
         "firstName": "Test",
         "lastName": "Script",
-        "role": "User",
+        "role": "Learner",
         "email": new_user_email,
         "password": "password",
     }
     body2 = {
         "firstName": "Test2",
         "lastName": "Script2",
-        "role": "User",
+        "role": "Learner",
         "email": new_user_email,
     }
     if lang != "ts":

--- a/frontend/src/constants/UserConstants.ts
+++ b/frontend/src/constants/UserConstants.ts
@@ -1,3 +1,3 @@
-const USER_ROLES = ["User", "Admin", "Staff"] as const;
+const USER_ROLES = ["Learner", "Admin", "Staff"] as const;
 
 export default USER_ROLES;


### PR DESCRIPTION
## Implementation Description
Closes #149.
From the ticket:

The name `User` is ambiguous and doesn't match the mockups. We should use the terminology `Learner` instead.

## Screenshots
N/A

## What should reviewers focus on?
- Do you see any side effects of this change _other than_ breaking the dev environment?
- Are there any usages you can think of which wouldn't have been found by just searching for `"User"`?

## Testing Procedure
- Play with the local environment.

## Things to Note
Will not merge this until Monday's work session so that we can (hopefully) notify more devs of the change.

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
