### PR TITLE
Lesson video component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "react-google-login": "^5.2.2",
     "react-json-schema": "^1.2.2",
     "react-jsonschema-form": "^1.8.1",
+    "react-player": "^2.10.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
     "react-table": "^7.7.0",

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -23,6 +23,7 @@ export interface ModalProps {
   cancelText?: string;
   confirmText?: string;
   spreadButtons?: boolean;
+  canSubmit?: boolean;
   size?: string;
   children?: React.ReactNode;
 }
@@ -36,6 +37,7 @@ export const Modal = ({
   cancelText = "Cancel",
   confirmText = "Confirm",
   spreadButtons = false,
+  canSubmit = true,
   children,
   ...rest
 }: ModalProps): React.ReactElement => {
@@ -50,7 +52,11 @@ export const Modal = ({
           {children}
         </ModalBody>
         <ModalFooter>
-          <Button onClick={onConfirm} mr="1rem">
+          <Button
+            backgroundColor={`${canSubmit ? "grey" : ""}`}
+            onClick={onConfirm}
+            mr="1rem"
+          >
             {confirmText}
           </Button>
           {spreadButtons && <Spacer />}

--- a/frontend/src/components/common/content/VideoBlock.tsx
+++ b/frontend/src/components/common/content/VideoBlock.tsx
@@ -1,0 +1,21 @@
+import { Spinner } from "@chakra-ui/react";
+import React from "react";
+import ReactPlayer from "react-player";
+import {
+  ContentBlockProps,
+  VideoBlockState,
+} from "../../../types/ContentBlockTypes";
+
+const VideoBlock = ({
+  block: { content },
+}: ContentBlockProps<VideoBlockState>): React.ReactElement => {
+  return (
+    <ReactPlayer
+      url={content.link}
+      fallback={<Spinner />}
+      alt="video alt here"
+    />
+  );
+};
+
+export default VideoBlock;

--- a/frontend/src/components/common/content/VideoBlock.tsx
+++ b/frontend/src/components/common/content/VideoBlock.tsx
@@ -13,7 +13,12 @@ const VideoBlock = ({
     <ReactPlayer
       url={content.link}
       fallback={<Spinner />}
-      alt="video alt here"
+      config={{
+        youtube: {
+          playerVars: { modestbranding: 1 },
+        },
+      }}
+      controls
     />
   );
 };

--- a/frontend/src/components/common/content/index.ts
+++ b/frontend/src/components/common/content/index.ts
@@ -1,4 +1,5 @@
-import ImageBlock from "./ImageBlock";
 import TextBlock from "./TextBlock";
+import ImageBlock from "./ImageBlock";
+import VideoBlock from "./VideoBlock";
 
-export { ImageBlock, TextBlock };
+export { TextBlock, ImageBlock, VideoBlock };

--- a/frontend/src/components/module-viewer/content/ContentBlock.tsx
+++ b/frontend/src/components/module-viewer/content/ContentBlock.tsx
@@ -3,12 +3,12 @@ import React, { useContext, useState } from "react";
 import { Draggable } from "react-beautiful-dnd";
 
 import { ContentBlockState } from "../../../types/ContentBlockTypes";
-import { TextBlock, ImageBlock } from "../../common/content";
+import { TextBlock, ImageBlock, VideoBlock } from "../../common/content";
 import DeleteModal from "../../common/DeleteModal";
 import EditContentOptionsMenu from "../EditContentOptionsMenu";
 
 import { ReactComponent as DragHandleIconSvg } from "../../../assets/DragHandle.svg";
-import { EditImageModal, EditTextModal } from "./modals";
+import { EditTextModal, EditImageModal, EditVideoModal } from "./modals";
 import createContentBlockRenderers, {
   EmptyConfigEntry as Empty,
 } from "../../common/content/ContentBlockRenderer";
@@ -28,7 +28,10 @@ const [CONTENT_BLOCKS, EDIT_MODALS] = createContentBlockRenderers({
     renderBlock: ImageBlock,
     renderEditModal: EditImageModal,
   },
-  video: Empty,
+  video: {
+    renderBlock: VideoBlock,
+    renderEditModal: EditVideoModal,
+  },
   audio: Empty,
 });
 

--- a/frontend/src/components/module-viewer/content/modals/EditVideoModal.tsx
+++ b/frontend/src/components/module-viewer/content/modals/EditVideoModal.tsx
@@ -1,11 +1,27 @@
-import { Flex, VStack } from "@chakra-ui/react";
+import { Box, Flex, Spinner, Text, VStack } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
+import ReactPlayer from "react-player";
 import { VideoBlockState } from "../../../../types/ContentBlockTypes";
 import { Modal } from "../../../common/Modal";
 import EditorContext from "../../../../contexts/ModuleEditorContext";
 
-import { TextArea } from "../../../common/TextArea";
+import { TextInput } from "../../../common/TextInput";
 import { EditContentModalProps } from "../../../../types/ModuleEditorTypes";
+
+const InvalidLinkPreview = (): React.ReactElement => {
+  return (
+    <Flex
+      height="350px"
+      justifyContent="center"
+      alignItems="center"
+      background="grey"
+    >
+      <Text variant="sm" color="black">
+        Invalid Link
+      </Text>
+    </Flex>
+  );
+};
 
 const EditVideoModal = ({
   block,
@@ -21,8 +37,7 @@ const EditVideoModal = ({
   const { dispatch } = context;
 
   const onSave = () => {
-    if (!link) {
-      setInvalid(true);
+    if (invalid) {
       return;
     }
     const newBlock = {
@@ -51,16 +66,40 @@ const EditVideoModal = ({
       onConfirm={onSave}
       onCancel={onClose}
       isOpen={isOpen}
+      canSubmit={invalid}
     >
       <Flex>
-        <VStack flex="1">
-          <TextArea
-            label="Text Content:"
+        <VStack flex="1" alignItems="left">
+          <TextInput
+            label="Link:"
             defaultValue={link}
-            onChange={setLink}
+            onChange={(e) => {
+              setInvalid(true);
+              setLink(e);
+            }}
             isInvalid={invalid}
-            errorMessage="This field is required."
+            errorMessage={link ? "invalid link" : "This field is required."}
           />
+          <Text variant="sm">Preview:</Text>
+          <div style={{ display: `${invalid ? "initial" : "none"}` }}>
+            <InvalidLinkPreview />
+          </div>
+          <Box display={invalid ? "none" : "initial"}>
+            <ReactPlayer
+              url={link}
+              fallback={<Spinner />}
+              config={{
+                youtube: {
+                  playerVars: { modestbranding: 1 },
+                },
+              }}
+              controls
+              width="100%"
+              onError={() => setInvalid(true)}
+              onReady={() => setInvalid(false)}
+            />
+          </Box>
+          )
         </VStack>
       </Flex>
     </Modal>

--- a/frontend/src/components/module-viewer/content/modals/EditVideoModal.tsx
+++ b/frontend/src/components/module-viewer/content/modals/EditVideoModal.tsx
@@ -1,0 +1,70 @@
+import { Flex, VStack } from "@chakra-ui/react";
+import React, { useContext, useState } from "react";
+import { VideoBlockState } from "../../../../types/ContentBlockTypes";
+import { Modal } from "../../../common/Modal";
+import EditorContext from "../../../../contexts/ModuleEditorContext";
+
+import { TextArea } from "../../../common/TextArea";
+import { EditContentModalProps } from "../../../../types/ModuleEditorTypes";
+
+const EditVideoModal = ({
+  block,
+  index,
+  isOpen,
+  onClose,
+}: EditContentModalProps<VideoBlockState>): React.ReactElement => {
+  const [link, setLink] = useState(block.content.link ?? "");
+  const [invalid, setInvalid] = useState(false);
+  const context = useContext(EditorContext);
+
+  if (!context) return <></>;
+  const { dispatch } = context;
+
+  const onSave = () => {
+    if (!link) {
+      setInvalid(true);
+      return;
+    }
+    const newBlock = {
+      ...block,
+      content: {
+        ...block.content,
+        link,
+      },
+    };
+
+    dispatch({
+      type: "update-block",
+      value: {
+        index,
+        block: newBlock,
+      },
+    });
+
+    onClose();
+  };
+
+  return (
+    <Modal
+      size="xl"
+      header="Edit Video Component"
+      onConfirm={onSave}
+      onCancel={onClose}
+      isOpen={isOpen}
+    >
+      <Flex>
+        <VStack flex="1">
+          <TextArea
+            label="Text Content:"
+            defaultValue={link}
+            onChange={setLink}
+            isInvalid={invalid}
+            errorMessage="This field is required."
+          />
+        </VStack>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default EditVideoModal;

--- a/frontend/src/components/module-viewer/content/modals/index.ts
+++ b/frontend/src/components/module-viewer/content/modals/index.ts
@@ -1,4 +1,5 @@
 import EditImageModal from "./EditImageModal";
 import EditTextModal from "./EditTextModal";
+import EditVideoModal from "./EditVideoModal";
 
-export { EditTextModal, EditImageModal };
+export { EditTextModal, EditImageModal, EditVideoModal };

--- a/frontend/src/reducers/ModuleEditorContextReducer.ts
+++ b/frontend/src/reducers/ModuleEditorContextReducer.ts
@@ -142,6 +142,15 @@ const createLessonContentBlock = (
         },
       };
       break;
+    case ContentTypeEnum.VIDEO.id:
+      block = {
+        type: ContentTypeEnum.VIDEO,
+        id: uuid(),
+        content: {
+          link: "https://www.youtube.com/watch?v=kMlkCYL9qo0",
+        },
+      };
+      break;
     default:
       throw Error("Invalid block id");
   }

--- a/frontend/src/types/ContentBlockTypes.ts
+++ b/frontend/src/types/ContentBlockTypes.ts
@@ -19,7 +19,12 @@ export type ImageBlockState = ContentBlockStateType<
     link: string;
   }
 >;
-export type VideoBlockState = ContentBlockStateType<"video">;
+export type VideoBlockState = ContentBlockStateType<
+  "video",
+  {
+    link: string;
+  }
+>;
 export type AudioBlockState = ContentBlockStateType<"audio">;
 
 export type ContentBlockState = RequireAllContentTypesArePresent<

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5214,7 +5214,7 @@ deep-is@^0.1.3, deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-deepmerge@^4.2.2:
+deepmerge@^4.0.0, deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
@@ -8399,6 +8399,11 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -10745,7 +10750,7 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-fast-compare@3.2.0:
+react-fast-compare@3.2.0, react-fast-compare@^3.0.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -10826,6 +10831,17 @@ react-overlays@^5.0.0:
     prop-types "^15.7.2"
     uncontrollable "^7.2.1"
     warning "^4.0.3"
+
+react-player@^2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/react-player/-/react-player-2.10.1.tgz#f2ee3ec31393d7042f727737545414b951ffc7e4"
+  integrity sha512-ova0jY1Y1lqLYxOehkzbNEju4rFXYVkr5rdGD71nsiG4UKPzRXQPTd3xjoDssheoMNjZ51mjT5ysTrdQ2tEvsg==
+  dependencies:
+    deepmerge "^4.0.0"
+    load-script "^1.0.0"
+    memoize-one "^5.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.0.1"
 
 react-redux@^7.2.0:
   version "7.2.6"


### PR DESCRIPTION
## Implementation Description
Brief summary of PR
Introduces the video component for lesson builder, where users can embed videos based on a provided link.

## Screenshots
Visual depiction of PR
<img width="575" alt="image" src="https://user-images.githubusercontent.com/36215359/179653618-c3e3dba7-f998-4d72-83d9-4d75fb584782.png">
<img width="562" alt="image" src="https://user-images.githubusercontent.com/36215359/179653654-f50de4a6-0eab-49a7-bd49-a91faf99923d.png">
<img width="941" alt="image" src="https://user-images.githubusercontent.com/36215359/179653680-484d79e8-c664-4c94-ab7a-6145d4a3ce03.png">

## What should reviewers focus on?
- Make sure you can create and delete the video component as with any other current lesson component currently.
- Ensure you can use any public video link (I tested on Vimeo and Youtube). Ensure that you can view previews and also play the video within the preview and in the lesson editor
- Ensure invalid videos are handled properly, and that you cannot save

## Testing Procedure
- Drag and drop a video
- Ensure the video is shown 
- Edit the video, ensure you can see a preview of it
- Change the video link to an invalid one, observe that it will say invalid and you cannot save
- Change the video to a new valid one, observe that you can preview it once again and save it
- Once saved, observe you can click play within the lesson editor, and that native controls exist 
- Observe you can save and delete video components

## Things to Note
- Added the react-player library to handle videos 
- Currently it defaults to some random svelte video I chose. Handling default behaviour on drag release is out of the scope of this ticket

## Checklist
- [X] Ensure code follows style guide by running the linters
- [X] I have updated the documentation or deemed it unnecessary
- [X] I have linked the relevant issue in this PR
- [X] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)