### PR TITLE
Make course/lesson info API routes public

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -9,6 +9,7 @@ import {
   isAuthorizedByRole,
   isAuthorizedByUserId,
   idNotSameAsActiveUser,
+  publicRoute,
 } from "../middlewares/auth";
 import and from "../middlewares/utils/combinatorsUtils";
 import authResolvers from "./resolvers/authResolvers";
@@ -86,8 +87,8 @@ const authorizeRoleChange = (id: string) => {
 
 const graphQLMiddlewares = {
   Query: {
-    course: authorizedByAllRoles(),
-    courses: authorizedByAllRoles(),
+    course: publicRoute,
+    courses: publicRoute,
     entity: authorizedByAllRoles(),
     entities: authorizedByAllRoles(),
     userById: authorizedByAdmin(),

--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -97,6 +97,7 @@ const graphQLMiddlewares = {
     userCountByTown: authorizedByAdmin(),
     lessonById: authorizedByAllRoles(),
     lessons: authorizedByAllRoles(),
+    lessonTitles: publicRoute,
     courseProgress: isAuthorizedByUserId("userId"),
     moduleProgress: isAuthorizedByUserId("userId"),
     lessonProgress: isAuthorizedByUserId("userId"),

--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -1,4 +1,4 @@
-import { AuthenticationError, ExpressContext } from "apollo-server-express";
+import { ExpressContext } from "apollo-server-express";
 import CourseService from "../../services/implementations/courseService";
 import {
   CreateCourseRequestDTO,
@@ -24,9 +24,10 @@ const emailService: IEmailService = new EmailService(nodemailerConfig);
 const authService: IAuthService = new AuthService(userService, emailService);
 
 const getCourseVisibilityAttributes = (
-  role: Role,
+  role: Role | null,
 ): CourseVisibilityAttributes => {
   switch (role) {
+    case null: // Logged-out users can see public published modules.
     case "Learner":
       return {
         includePrivateCourses: false,
@@ -55,12 +56,6 @@ const courseResolvers = {
       context: ExpressContext,
     ): Promise<CourseResponseDTO> => {
       const accessToken = getAccessToken(context.req);
-      if (!accessToken) {
-        throw new AuthenticationError(
-          "Failed authentication and/or authorization by role",
-        );
-      }
-
       const role = await authService.getUserRoleByAccessToken(accessToken);
       const attributes = getCourseVisibilityAttributes(role);
 
@@ -72,12 +67,6 @@ const courseResolvers = {
       context: ExpressContext,
     ): Promise<CourseResponseDTO[]> => {
       const accessToken = getAccessToken(context.req);
-      if (!accessToken) {
-        throw new AuthenticationError(
-          "Failed authentication and/or authorization by role",
-        );
-      }
-
       const role = await authService.getUserRoleByAccessToken(accessToken);
       const attributes = getCourseVisibilityAttributes(role);
 

--- a/backend/graphql/resolvers/lessonResolvers.ts
+++ b/backend/graphql/resolvers/lessonResolvers.ts
@@ -22,6 +22,12 @@ const lessonResolvers = {
     ): Promise<LessonResponseDTO[]> => {
       return Promise.all(ids.map(lessonService.getLessonById));
     },
+    lessonTitles: async (
+      _parent: undefined,
+      { ids }: { ids: string[] },
+    ): Promise<Array<string>> => {
+      return lessonService.getLessonTitlesByIds(ids);
+    },
   },
   Mutation: {
     createLesson: async (

--- a/backend/graphql/types/lessonType.ts
+++ b/backend/graphql/types/lessonType.ts
@@ -52,6 +52,7 @@ const lessonType = gql`
   extend type Query {
     lessonById(id: ID!): LessonResponseDTO!
     lessons(ids: [ID!]!): [LessonResponseDTO!]!
+    lessonTitles(ids: [ID!]!): [String!]!
   }
 
   extend type Mutation {

--- a/backend/middlewares/auth.ts
+++ b/backend/middlewares/auth.ts
@@ -11,14 +11,14 @@ const authService: IAuthService = new AuthService(new UserService());
 
 export const getAccessToken = (req: Request): string | null => {
   const [scheme, token] = req.headers.authorization?.split(" ") || [];
-  if (scheme.toLowerCase() === "bearer") {
+  if (scheme?.toLowerCase() === "bearer") {
     return token === "null" ? null : token;
   }
   return null;
 };
 
-/* Determine if the user whose role is to be changed does not match the currently 
-logged in user. 
+/* Determine if the user whose role is to be changed does not match the currently
+logged in user.
  * Note: userIdField is the name of the request parameter containing the requested userId */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */

--- a/backend/middlewares/auth.ts
+++ b/backend/middlewares/auth.ts
@@ -10,13 +10,9 @@ import { Role } from "../types";
 const authService: IAuthService = new AuthService(new UserService());
 
 export const getAccessToken = (req: Request): string | null => {
-  const authHeaderParts = req.headers.authorization?.split(" ");
-  if (
-    authHeaderParts &&
-    authHeaderParts.length >= 2 &&
-    authHeaderParts[0].toLowerCase() === "bearer"
-  ) {
-    return authHeaderParts[1];
+  const [scheme, token] = req.headers.authorization?.split(" ") || [];
+  if (scheme.toLowerCase() === "bearer") {
+    return token === "null" ? null : token;
   }
   return null;
 };
@@ -50,6 +46,22 @@ export const idNotSameAsActiveUser = (userIdField: string) => {
     return resolve(parent, args, context, info);
   };
 };
+
+/* Mark request as always authorized */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+export const publicRoute = async (
+  resolve: (
+    parent: any,
+    args: { [key: string]: any },
+    context: ExpressContext,
+    info: GraphQLResolveInfo,
+  ) => any,
+  parent: any,
+  args: { [key: string]: any },
+  context: ExpressContext,
+  info: GraphQLResolveInfo,
+) => resolve(parent, args, context, info);
 
 /* Determine if request is authorized based on accessToken validity and role of client */
 /* eslint-disable @typescript-eslint/no-explicit-any */

--- a/backend/services/implementations/authService.ts
+++ b/backend/services/implementations/authService.ts
@@ -148,7 +148,13 @@ class AuthService implements IAuthService {
     }
   }
 
-  async getUserRoleByAccessToken(accessToken: string): Promise<Role> {
+  getUserRoleByAccessToken(accessToken: string): Promise<Role>;
+  getUserRoleByAccessToken(accessToken: null): Promise<null>;
+  async getUserRoleByAccessToken(
+    accessToken: string | null,
+  ): Promise<Role | null> {
+    if (accessToken == null) return null;
+
     try {
       const decodedIdToken: firebaseAdmin.auth.DecodedIdToken = await firebaseAdmin
         .auth()

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -35,6 +35,25 @@ class LessonService implements ILessonService {
     };
   }
 
+  async getLessonTitlesByIds(ids: Array<string>): Promise<Array<string>> {
+    let lessons: Array<Lesson> | null;
+    try {
+      lessons = await MgLesson.find({ _id: { $in: ids } }, { title: 1 });
+      if (!lessons) {
+        throw new Error(`Lesson id from ${ids} not found`);
+      }
+    } catch (error: unknown) {
+      Logger.error(`Failed to get lesson. Reason = ${getErrorMessage(error)}`);
+      throw error;
+    }
+
+    const idToTitle: { [key: string]: string } = {};
+    lessons.forEach((lesson) => {
+      idToTitle[lesson.id] = lesson.title;
+    });
+    return ids.map((id) => idToTitle[id]);
+  }
+
   async createLesson(
     lesson: CreateLessonRequestDTO,
   ): Promise<LessonResponseDTO> {

--- a/backend/services/interfaces/ILessonService.ts
+++ b/backend/services/interfaces/ILessonService.ts
@@ -37,6 +37,14 @@ export interface ILessonService {
   getLessonById(id: string): Promise<LessonResponseDTO>;
 
   /**
+   * retrieve the title of the lessons with the given ids
+   * @param ids lesson ids
+   * @returns requested Lesson titles
+   * @throws Error if retrieval fails
+   */
+  getLessonTitlesByIds(ids: Array<string>): Promise<Array<string>>;
+
+  /**
    * create a Lesson with the fields given in the DTO, return created Lesson
    * @param lesson to be created
    * @returns the created Lesson

--- a/backend/services/interfaces/authService.ts
+++ b/backend/services/interfaces/authService.ts
@@ -71,6 +71,8 @@ interface IAuthService {
    * @throws Error if no user role found
    */
   getUserRoleByAccessToken(accessToken: string): Promise<Role>;
+  getUserRoleByAccessToken(accessToken: null): Promise<null>;
+  getUserRoleByAccessToken(accessToken: string | null): Promise<Role | null>;
 
   /**
    * Determine if the provided access token is valid and issued to the requested user


### PR DESCRIPTION
## Implementation Description
- Make course info API routes public
- Add new public route returning minimal lesson information

The commits are disjoint so I'd recommend reviewing by commit.

## Screenshots
N/A

## What should reviewers focus on?
- Is the logic secure?
- Does the new route cover all remaining use cases for public lesson info?

## Testing Procedure
Checkout branch and try GQL endpoints as a non-logged-in user.

## Things to Note
None

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
