### PR TITLE
Fix 1h account logout issues

### DIFF
--- a/frontend/src/APIClients/AuthAPIClient.ts
+++ b/frontend/src/APIClients/AuthAPIClient.ts
@@ -132,17 +132,19 @@ type RefreshFunction = (
   >
 >;
 
-const refresh = async (refreshFunction: RefreshFunction): Promise<boolean> => {
+const refresh = async (
+  refreshFunction: RefreshFunction,
+): Promise<string | null> => {
   try {
     const result = await refreshFunction({ variables: {} });
     const token = result.data?.refresh;
     if (!token) {
-      return false;
+      return null;
     }
     setLocalStorageObjProperty(AUTHENTICATED_USER_KEY, "accessToken", token);
-    return true;
+    return token;
   } catch (error) {
-    return false;
+    return null;
   }
 };
 

--- a/frontend/src/utils/AuthUtils.ts
+++ b/frontend/src/utils/AuthUtils.ts
@@ -35,11 +35,10 @@ const getRefreshedAccessToken = async (
   return token;
 };
 
+// Implementation idea thanks to https://stackoverflow.com/a/70324598/3761440.
 export const refreshAccessToken = (() => {
   let pendingRefreshPromise: Promise<string> | null = null;
-  return async (
-    client: ApolloClient<NormalizedCacheObject>,
-  ): Promise<string> => {
+  return (client: ApolloClient<NormalizedCacheObject>): Promise<string> => {
     if (!pendingRefreshPromise) {
       pendingRefreshPromise = getRefreshedAccessToken(client).finally(() => {
         pendingRefreshPromise = null;

--- a/frontend/src/utils/AuthUtils.ts
+++ b/frontend/src/utils/AuthUtils.ts
@@ -1,0 +1,50 @@
+import { ApolloClient, NormalizedCacheObject } from "@apollo/client";
+import jwt from "jsonwebtoken";
+import AUTHENTICATED_USER_KEY from "../constants/AuthConstants";
+import { getLocalStorageObjProperty } from "./LocalStorageUtils";
+import { REFRESH } from "../APIClients/mutations/AuthMutations";
+import AuthAPIClient from "../APIClients/AuthAPIClient";
+
+export const getLocalAccessToken = (): string => {
+  return getLocalStorageObjProperty(
+    AUTHENTICATED_USER_KEY,
+    "accessToken",
+  ) as string;
+};
+
+const EXPIRY_BUFFER_MINS = 1;
+
+export const isAccessTokenExpired = (accessToken: string): boolean => {
+  const decodedToken = jwt.decode(String(accessToken));
+  const currTime = Math.round(new Date().getTime() / 1000);
+  return (
+    typeof decodedToken !== "object" ||
+    !decodedToken ||
+    !decodedToken.exp ||
+    decodedToken.exp <= currTime + EXPIRY_BUFFER_MINS * 60
+  );
+};
+
+const getRefreshedAccessToken = async (
+  client: ApolloClient<NormalizedCacheObject>,
+) => {
+  const token = await AuthAPIClient.refresh(() =>
+    client.mutate({ mutation: REFRESH }),
+  );
+  if (!token) throw new Error("Failed to refresh access token!");
+  return token;
+};
+
+export const refreshAccessToken = (() => {
+  let pendingRefreshPromise: Promise<string> | null = null;
+  return async (
+    client: ApolloClient<NormalizedCacheObject>,
+  ): Promise<string> => {
+    if (!pendingRefreshPromise) {
+      pendingRefreshPromise = getRefreshedAccessToken(client).finally(() => {
+        pendingRefreshPromise = null;
+      });
+    }
+    return pendingRefreshPromise;
+  };
+})();


### PR DESCRIPTION
## Implementation Description
- Update GraphQL error logging code to be more useful to devs
- Update BaseAPIClient token injection to refresh if necessary

The crux of the issue was that with Firebase, we're supposed to refresh our access tokens every hour, but we weren't doing that at all. This PR updates our GraphQL client so that any request with an expired token will request a new token before the request goes through.

The PR also greatly improves the GraphQL logging logic to help devs with debugging. Since the PR includes this secondary debugging fix, I'd recommend reviewing by commit.

## Screenshots
![image](https://user-images.githubusercontent.com/9922514/183307920-2ddf20a0-bb88-4121-b996-36624fb9b31e.png)


## What should reviewers focus on?
- Is the code clean and well-structured?
- Is this scheme secure?

## Testing Procedure
Two options:
1. If you're only planning on testing once (risky since you may have to wait an hour each time you want to re-test):
    1. Open the preview URL, log in with an admin account, visit `/admin/courses`, and wait an hour.
    1. Open the console (`F12`) and refresh the page. Verify that a "refreshing access token" message appears and you're still able to interact with the page as an admin.
2. If you're planning on testing a few times (this will only work if your access token has already expired locally, i.e., it's been an hour since you've logged in locally)
    1. Checkout the `main` branch locally.
    1. Open `frontend/src/APIClients/BaseAPIClient.ts`, and comment out lines `50-51` which clear your `localStorage`.
    1. Visit your local site at `/admin/courses`.
    1. When the page becomes blank with an error, open the console (`F12`) and copy the contents of your local storage into a text file.
    1. Reset all your code changes.
    1. Pull this PR's branch down onto your computer.
    1. Load `/admin/courses`.
    1. Open the console (`F12`) and refresh the page. Verify that a "refreshing access token" message appears and you're still able to interact with the page as an admin.
    1. If you need to test again, copy the contents of `localStorage` you saved in a text file and assign them to your `localStorage`, then perform the previous step as required.

## Things to Note
N/A

## Checklist
- [x] Ensure code follows style guide by running the linters
- [x] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [x] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
