### PR TITLE
Heading component

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     hooks:
     -   id: felint
         name: Lint frontend files
-        files: ^frontend/.*\.[jt]sx?$
+        files: ^frontend/src/.*\.[jt]sx?$
         types: [file]
         language: system
         entry: ./scripts/lint.sh felint

--- a/backend/graphql/types/lessonType.ts
+++ b/backend/graphql/types/lessonType.ts
@@ -3,11 +3,13 @@ import { gql } from "apollo-server-express";
 const lessonType = gql`
   type Content {
     link: String
+    size: String
     text: String
   }
 
   input ContentInput {
     link: String
+    size: String
     text: String
   }
 

--- a/backend/middlewares/validators/util.ts
+++ b/backend/middlewares/validators/util.ts
@@ -1,4 +1,10 @@
-import { ContentBlock, ImageBlock, TextBlock, VideoBlock } from "../../types";
+import {
+  ContentBlock,
+  HeadingBlock,
+  ImageBlock,
+  TextBlock,
+  VideoBlock,
+} from "../../types";
 
 type Type = "string" | "integer" | "boolean";
 
@@ -76,6 +82,10 @@ export const validateContent = (content: ContentBlock): boolean => {
     case "video": {
       const video = content as VideoBlock;
       return video.content.link != null;
+    }
+    case "heading": {
+      const heading = content as HeadingBlock;
+      return heading.content.size != null && heading.content.text != null;
     }
     default: {
       return false;

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -90,12 +90,16 @@ class LessonService implements ILessonService {
       if (!updatedLesson) {
         throw new Error(`Lesson id ${id} not found`);
       }
+      console.log("updated content is");
+      console.log(updatedLesson);
     } catch (error: unknown) {
       Logger.error(
         `Failed to update lesson. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }
+    console.log("Updated lesson content is");
+    console.log(updatedLesson.content);
 
     return {
       id: updatedLesson.id,

--- a/backend/services/implementations/lessonService.ts
+++ b/backend/services/implementations/lessonService.ts
@@ -90,16 +90,12 @@ class LessonService implements ILessonService {
       if (!updatedLesson) {
         throw new Error(`Lesson id ${id} not found`);
       }
-      console.log("updated content is");
-      console.log(updatedLesson);
     } catch (error: unknown) {
       Logger.error(
         `Failed to update lesson. Reason = ${getErrorMessage(error)}`,
       );
       throw error;
     }
-    console.log("Updated lesson content is");
-    console.log(updatedLesson.content);
 
     return {
       id: updatedLesson.id,

--- a/backend/types.ts
+++ b/backend/types.ts
@@ -1,6 +1,6 @@
 export type Role = "Learner" | "Admin" | "Staff";
 
-export type ContentType = "text" | "image" | "video";
+export type ContentType = "text" | "image" | "video" | "heading";
 export interface ContentBlock {
   type: ContentType;
   content: Record<string, unknown>;
@@ -16,6 +16,10 @@ export interface ImageBlock extends ContentBlock {
 
 export interface VideoBlock extends ContentBlock {
   content: { link: string };
+}
+
+export interface HeadingBlock extends ContentBlock {
+  content: { text: string; size: string };
 }
 
 export type Token = {

--- a/frontend/src/APIClients/mutations/LessonMutations.ts
+++ b/frontend/src/APIClients/mutations/LessonMutations.ts
@@ -12,6 +12,7 @@ export const CREATE_LESSON = gql`
       content {
         type
         content {
+          size
           link
           text
         }
@@ -32,6 +33,7 @@ export const UPDATE_LESSON = gql`
       content {
         type
         content {
+          size
           link
           text
         }

--- a/frontend/src/APIClients/queries/LessonQueries.ts
+++ b/frontend/src/APIClients/queries/LessonQueries.ts
@@ -14,6 +14,7 @@ const GET_LESSONS = gql`
         content {
           link
           text
+          size
         }
       }
     }

--- a/frontend/src/components/common/CustomHeading.tsx
+++ b/frontend/src/components/common/CustomHeading.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Heading } from "@chakra-ui/react";
+import { ValidHeadingSizes } from "../../types/ModuleEditorTypes";
+
+interface HeadingState {
+  size: string;
+  text: string;
+}
+
+const sizeToHeadingType = (size: string) => {
+  switch (size) {
+    case ValidHeadingSizes.heading1:
+      return "h1";
+    case ValidHeadingSizes.heading2:
+      return "h2";
+    case ValidHeadingSizes.heading3:
+      return "h3";
+    case ValidHeadingSizes.heading4:
+      return "h4";
+    default:
+      return "h1";
+  }
+};
+
+const CustomHeading = ({ size, text }: HeadingState): React.ReactElement => {
+  return (
+    <Heading as={sizeToHeadingType(size)} fontSize={size}>
+      {text}
+    </Heading>
+  );
+};
+
+export default CustomHeading;

--- a/frontend/src/components/common/content/HeadingBlock.tsx
+++ b/frontend/src/components/common/content/HeadingBlock.tsx
@@ -1,0 +1,15 @@
+import { Heading } from "@chakra-ui/react";
+import React from "react";
+
+import {
+  ContentBlockProps,
+  HeadingBlockState,
+} from "../../../types/ContentBlockTypes";
+
+const HeadingBlock = ({
+  block: { content },
+}: ContentBlockProps<HeadingBlockState>): React.ReactElement => {
+  return <Heading fontSize={content.size}>{content.text}</Heading>;
+};
+
+export default HeadingBlock;

--- a/frontend/src/components/common/content/HeadingBlock.tsx
+++ b/frontend/src/components/common/content/HeadingBlock.tsx
@@ -1,6 +1,5 @@
-import { Heading } from "@chakra-ui/react";
 import React from "react";
-
+import CustomHeading from "../CustomHeading";
 import {
   ContentBlockProps,
   HeadingBlockState,
@@ -9,7 +8,7 @@ import {
 const HeadingBlock = ({
   block: { content },
 }: ContentBlockProps<HeadingBlockState>): React.ReactElement => {
-  return <Heading fontSize={content.size}>{content.text}</Heading>;
+  return <CustomHeading size={content.size} text={content.text} />;
 };
 
 export default HeadingBlock;

--- a/frontend/src/components/common/content/index.ts
+++ b/frontend/src/components/common/content/index.ts
@@ -1,5 +1,6 @@
 import TextBlock from "./TextBlock";
 import ImageBlock from "./ImageBlock";
 import VideoBlock from "./VideoBlock";
+import HeadingBlock from "./HeadingBlock";
 
-export { TextBlock, ImageBlock, VideoBlock };
+export { TextBlock, ImageBlock, VideoBlock, HeadingBlock };

--- a/frontend/src/components/learner/ModuleLessonCount.tsx
+++ b/frontend/src/components/learner/ModuleLessonCount.tsx
@@ -14,14 +14,16 @@ const ModuleLessonCount = ({
   color = "text.default",
 }: ModuleLessonCountProps): React.ReactElement => {
   return (
-    <Box>
+    <Box color={color}>
       <Icon
         as={DocumentIcon}
         marginTop="-4px"
         marginRight="3px"
         color={color}
+        boxSize={25}
       />
-      {moduleCount} modules &bull; {lessonCount} lessons
+      {moduleCount} {`${moduleCount > 1 ? "modules" : "module"}`} &bull;{" "}
+      {lessonCount} {`${lessonCount > 1 ? "lessons" : "lesson"}`}
     </Box>
   );
 };

--- a/frontend/src/components/module-viewer/content/ContentBlock.tsx
+++ b/frontend/src/components/module-viewer/content/ContentBlock.tsx
@@ -3,12 +3,22 @@ import React, { useContext, useState } from "react";
 import { Draggable } from "react-beautiful-dnd";
 
 import { ContentBlockState } from "../../../types/ContentBlockTypes";
-import { TextBlock, ImageBlock, VideoBlock } from "../../common/content";
+import {
+  TextBlock,
+  ImageBlock,
+  VideoBlock,
+  HeadingBlock,
+} from "../../common/content";
 import DeleteModal from "../../common/DeleteModal";
 import EditContentOptionsMenu from "../EditContentOptionsMenu";
 
 import { ReactComponent as DragHandleIconSvg } from "../../../assets/DragHandle.svg";
-import { EditTextModal, EditImageModal, EditVideoModal } from "./modals";
+import {
+  EditTextModal,
+  EditImageModal,
+  EditVideoModal,
+  EditHeadingModal,
+} from "./modals";
 import createContentBlockRenderers, {
   EmptyConfigEntry as Empty,
 } from "../../common/content/ContentBlockRenderer";
@@ -17,7 +27,10 @@ import EditorContext from "../../../contexts/ModuleEditorContext";
 
 const [CONTENT_BLOCKS, EDIT_MODALS] = createContentBlockRenderers({
   column: Empty,
-  heading: Empty,
+  heading: {
+    renderBlock: HeadingBlock,
+    renderEditModal: EditHeadingModal,
+  },
   text: {
     renderBlock: TextBlock,
     renderEditModal: EditTextModal,

--- a/frontend/src/components/module-viewer/content/modals/EditHeadingModal.tsx
+++ b/frontend/src/components/module-viewer/content/modals/EditHeadingModal.tsx
@@ -1,10 +1,4 @@
-import {
-  Select,
-  FormControl,
-  FormLabel,
-  Input,
-  Heading,
-} from "@chakra-ui/react";
+import { Select, FormControl, FormLabel, Input, Box } from "@chakra-ui/react";
 import React, { useContext, useState } from "react";
 import { HeadingBlockState } from "../../../../types/ContentBlockTypes";
 import { Modal } from "../../../common/Modal";
@@ -13,6 +7,7 @@ import {
   EditContentModalProps,
   ValidHeadingSizes,
 } from "../../../../types/ModuleEditorTypes";
+import CustomHeading from "../../../common/CustomHeading";
 
 const EditHeadingModal = ({
   block,
@@ -20,10 +15,8 @@ const EditHeadingModal = ({
   isOpen,
   onClose,
 }: EditContentModalProps<HeadingBlockState>): React.ReactElement => {
-  const [text, setText] = useState(block.content.text ?? "why");
-  const [size, setSize] = useState(
-    block.content.size ?? ValidHeadingSizes.heading1,
-  );
+  const [text, setText] = useState(block.content.text);
+  const [size, setSize] = useState(block.content.size);
   const [invalid, setInvalid] = useState(false);
   const context = useContext(EditorContext);
   if (!context) return <></>;
@@ -89,9 +82,11 @@ const EditHeadingModal = ({
             Heading 3 ({ValidHeadingSizes.heading3})
           </option>
           <option value={ValidHeadingSizes.heading4}>
-            Heading 4({ValidHeadingSizes.heading4})
+            Heading 4 ({ValidHeadingSizes.heading4})
           </option>
         </Select>
+      </FormControl>
+      <FormControl isInvalid={invalid} isRequired>
         <FormLabel
           htmlFor="displayText"
           variant="caption-md"
@@ -110,25 +105,13 @@ const EditHeadingModal = ({
             setText(newText.target.value);
           }}
         />
-        <FormLabel
-          htmlFor="preview"
-          variant="caption-md"
-          marginTop="2vh"
-          marginBottom="1vh"
-        >
-          Preview
-        </FormLabel>
-        <Heading
-          type="preview"
-          fontSize={size}
-          borderWidth="1px" // CHECK THIS WITH JULIAN AS WELL
-          borderRadius="5px"
-          align="center"
-          padding="3vh 0"
-        >
-          {text || "Heading"}
-        </Heading>
       </FormControl>
+      <FormLabel variant="caption-md" marginTop="2vh" marginBottom="1vh">
+        Preview
+      </FormLabel>
+      <Box borderWidth="1px" borderRadius="5px" align="center" padding="3vh 0">
+        <CustomHeading size={size} text={text} />
+      </Box>
     </Modal>
   );
 };

--- a/frontend/src/components/module-viewer/content/modals/EditHeadingModal.tsx
+++ b/frontend/src/components/module-viewer/content/modals/EditHeadingModal.tsx
@@ -66,7 +66,7 @@ const EditHeadingModal = ({
         <FormLabel
           htmlFor="headingSize"
           variant="caption-md"
-          marginTop="4vh"
+          marginTop="1vh"
           marginBottom="1vh"
         >
           Heading Style

--- a/frontend/src/components/module-viewer/content/modals/EditHeadingModal.tsx
+++ b/frontend/src/components/module-viewer/content/modals/EditHeadingModal.tsx
@@ -1,0 +1,136 @@
+import {
+  Select,
+  FormControl,
+  FormLabel,
+  Input,
+  Heading,
+} from "@chakra-ui/react";
+import React, { useContext, useState } from "react";
+import { HeadingBlockState } from "../../../../types/ContentBlockTypes";
+import { Modal } from "../../../common/Modal";
+import EditorContext from "../../../../contexts/ModuleEditorContext";
+import {
+  EditContentModalProps,
+  ValidHeadingSizes,
+} from "../../../../types/ModuleEditorTypes";
+
+const EditHeadingModal = ({
+  block,
+  index,
+  isOpen,
+  onClose,
+}: EditContentModalProps<HeadingBlockState>): React.ReactElement => {
+  const [text, setText] = useState(block.content.text ?? "why");
+  const [size, setSize] = useState(
+    block.content.size ?? ValidHeadingSizes.heading1,
+  );
+  const [invalid, setInvalid] = useState(false);
+  const context = useContext(EditorContext);
+  if (!context) return <></>;
+  const { dispatch } = context;
+
+  const onSave = () => {
+    if (!(size && text)) {
+      setInvalid(true);
+      return;
+    }
+    const newBlock = {
+      ...block,
+      content: {
+        ...block.content,
+        text,
+        size,
+      },
+    };
+
+    dispatch({
+      type: "update-block",
+      value: {
+        index,
+        block: newBlock,
+      },
+    });
+
+    onClose();
+  };
+
+  return (
+    <Modal
+      size="xl"
+      header="Heading"
+      onConfirm={onSave}
+      onCancel={onClose}
+      isOpen={isOpen}
+    >
+      <FormControl isInvalid={invalid} isRequired>
+        <FormLabel
+          htmlFor="headingSize"
+          variant="caption-md"
+          marginTop="4vh"
+          marginBottom="1vh"
+        >
+          Heading Style
+        </FormLabel>
+        <Select
+          type="headingSize"
+          defaultValue={size}
+          onChange={(newSize) => {
+            setInvalid(false);
+            setSize(newSize.target.value);
+          }}
+        >
+          <option value={ValidHeadingSizes.heading1}>
+            Heading 1 ({ValidHeadingSizes.heading1})
+          </option>
+          <option value={ValidHeadingSizes.heading2}>
+            Heading 2 ({ValidHeadingSizes.heading2})
+          </option>
+          <option value={ValidHeadingSizes.heading3}>
+            Heading 3 ({ValidHeadingSizes.heading3})
+          </option>
+          <option value={ValidHeadingSizes.heading4}>
+            Heading 4({ValidHeadingSizes.heading4})
+          </option>
+        </Select>
+        <FormLabel
+          htmlFor="displayText"
+          variant="caption-md"
+          marginTop="2vh"
+          marginBottom="1vh"
+        >
+          Display Text
+        </FormLabel>
+        <Input
+          label="Display Text"
+          type="displayText"
+          isRequired
+          defaultValue={text}
+          onChange={(newText) => {
+            setInvalid(false);
+            setText(newText.target.value);
+          }}
+        />
+        <FormLabel
+          htmlFor="preview"
+          variant="caption-md"
+          marginTop="2vh"
+          marginBottom="1vh"
+        >
+          Preview
+        </FormLabel>
+        <Heading
+          type="preview"
+          fontSize={size}
+          borderWidth="1px" // CHECK THIS WITH JULIAN AS WELL
+          borderRadius="5px"
+          align="center"
+          padding="3vh 0"
+        >
+          {text || "Heading"}
+        </Heading>
+      </FormControl>
+    </Modal>
+  );
+};
+
+export default EditHeadingModal;

--- a/frontend/src/components/module-viewer/content/modals/index.ts
+++ b/frontend/src/components/module-viewer/content/modals/index.ts
@@ -1,5 +1,6 @@
 import EditImageModal from "./EditImageModal";
 import EditTextModal from "./EditTextModal";
 import EditVideoModal from "./EditVideoModal";
+import EditHeadingModal from "./EditHeadingModal";
 
-export { EditTextModal, EditImageModal, EditVideoModal };
+export { EditTextModal, EditImageModal, EditVideoModal, EditHeadingModal };

--- a/frontend/src/components/pages/CourseOverview.tsx
+++ b/frontend/src/components/pages/CourseOverview.tsx
@@ -1,9 +1,38 @@
 import React from "react";
-import { Box, Flex, VStack } from "@chakra-ui/react";
+import { useHistory, useParams } from "react-router-dom";
+import { ChevronLeftIcon } from "@chakra-ui/icons";
+import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
 import Banner from "../learner/Banner";
 import ModuleLessonCount from "../learner/ModuleLessonCount";
+import { GET_COURSE } from "../../APIClients/queries/CourseQueries";
+import { HOME_PAGE } from "../../constants/Routes";
+import { CourseOverviewParams } from "../../types/CourseOverviewTypes";
+import { ModuleType } from "../../types/ModuleEditorTypes";
 
-const ViewCourse = (): React.ReactElement => {
+const CourseOverview = (): React.ReactElement => {
+  const history = useHistory();
+  const { courseID }: CourseOverviewParams = useParams();
+  const { data: courseData } = useQuery(GET_COURSE, {
+    variables: {
+      id: courseID,
+    },
+  });
+
+  const onReturnToCourseOverviewClick = () => {
+    history.push(HOME_PAGE);
+  };
+
+  const getLessonCount = () => {
+    let lessonCount = 0;
+
+    courseData?.course?.modules?.forEach((moduleContent: ModuleType) => {
+      lessonCount += moduleContent?.lessons?.length;
+    });
+
+    return lessonCount;
+  };
+
   return (
     <Flex direction="column">
       <Banner />
@@ -11,15 +40,29 @@ const ViewCourse = (): React.ReactElement => {
         px="120px"
         py="20px"
         height="400px"
-        background="background.dark"
+        background="background.lightgrey"
         color="white"
         align="center"
       >
-        <VStack flex="2" align="start">
-          <span>breadcrumb here</span>
-          <span>title here</span>
-          <span>description here</span>
-          <ModuleLessonCount color="white" moduleCount={10} lessonCount={24} />
+        <VStack flex="2" align="start" spacing={4} pr={6}>
+          <Box display="flex">
+            <Button onClick={onReturnToCourseOverviewClick} variant="link">
+              <ChevronLeftIcon color="brand.royal" mr="15px" boxSize={30} />
+              <Text variant="display-xs" color="brand.royal">
+                Return to Course Browsing
+              </Text>
+            </Button>
+          </Box>
+          <Text variant="display-lg" color="text.default">
+            {courseData?.course?.title}
+          </Text>
+          <Text variant="body" color="text.default">
+            {courseData?.course?.description}
+          </Text>
+          <ModuleLessonCount
+            moduleCount={courseData?.course?.modules?.length}
+            lessonCount={getLessonCount()}
+          />
         </VStack>
         <Flex
           direction="column"
@@ -41,4 +84,4 @@ const ViewCourse = (): React.ReactElement => {
   );
 };
 
-export default ViewCourse;
+export default CourseOverview;

--- a/frontend/src/reducers/ModuleEditorContextReducer.ts
+++ b/frontend/src/reducers/ModuleEditorContextReducer.ts
@@ -5,6 +5,7 @@ import {
   LessonType,
   EditorChangeStatus,
   EditorChangeStatuses,
+  ValidHeadingSizes,
 } from "../types/ModuleEditorTypes";
 import { ContentBlockState, ContentTypeEnum } from "../types/ContentBlockTypes";
 
@@ -175,6 +176,16 @@ const createLessonContentBlock = (
         id: uuid(),
         content: {
           link: "",
+        },
+      };
+      break;
+    case ContentTypeEnum.HEADING.id:
+      block = {
+        type: ContentTypeEnum.HEADING,
+        id: uuid(),
+        content: {
+          text: "",
+          size: ValidHeadingSizes.heading1,
         },
       };
       break;

--- a/frontend/src/types/ContentBlockTypes.ts
+++ b/frontend/src/types/ContentBlockTypes.ts
@@ -4,7 +4,13 @@ import { ContentType } from "../APIClients/types/LessonClientTypes";
 export const ContentTypeCategories = ["Layout", "Basic", "Media"];
 
 export type ColumnBlockState = ContentBlockStateType<"column">;
-export type HeadingBlockState = ContentBlockStateType<"heading">;
+export type HeadingBlockState = ContentBlockStateType<
+  "heading",
+  {
+    size: string;
+    text: string;
+  }
+>;
 export type TextBlockState = ContentBlockStateType<
   "text",
   {

--- a/frontend/src/types/CourseOverviewTypes.ts
+++ b/frontend/src/types/CourseOverviewTypes.ts
@@ -1,0 +1,4 @@
+export interface CourseOverviewParams {
+  courseID: string;
+  moduleIndex: string;
+}

--- a/frontend/src/types/ModuleEditorTypes.ts
+++ b/frontend/src/types/ModuleEditorTypes.ts
@@ -98,6 +98,13 @@ export type EditorContextAction =
       value: number;
     };
 
+export enum ValidHeadingSizes {
+  heading1 = "48px",
+  heading2 = "32px",
+  heading3 = "24px",
+  heading4 = "16px",
+}
+
 export interface EditContentOptionsMenuProps {
   isVisible: boolean;
   onEditClick: () => void;


### PR DESCRIPTION
## Implementation Description
Added heading component to lessons, customizable text and size. This allows RHS to break their lessons into blocks

## Screenshots

![image](https://user-images.githubusercontent.com/36215359/184506496-f9bd9628-839e-4c56-90a5-fed11e9ad6f4.png)
## What should reviewers focus on?
- Ability to create a heading component, change the text, and the size
- By default (if no text is provided), the preview will just say heading.
- If no text is entered and someone tries to submit, it will fail
- After saving, you can refresh and see that the changes are still there

## Testing Procedure

- Create a heading component
- Change the size, and the text.
- Observe if you change text to be empty it will fail to save
- Observe after submitting but before saving changes the changes are shown
- Observe that after saving changes, refreshing the page, the changes still exist.

## Things to Note

## Checklist
- [X] Ensure code follows style guide by running the linters
- [X] I have updated the documentation or deemed it unnecessary
- [X] I have linked the relevant issue in this PR
- [X] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)