### PR TITLE
Fix mismatched endpoint name for Signup

### DIFF
--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -73,7 +73,7 @@ const accessTokenInjectionLink = new ApolloLink(
 
 const refreshDirectionalLink = new RetryLink().split(
   (operation) =>
-    ["Refresh", "ResetPassword", "Login", "SignUp"].includes(
+    ["Refresh", "ResetPassword", "Login", "Signup_Register"].includes(
       operation.operationName,
     ),
   authFromLocalLink.concat(httpLink),


### PR DESCRIPTION
## Implementation Description
We were refreshing the auth token for signup endpoints due to a naming issue, which caused auth errors. This PR migrates `SignUp` -> `Signup_Register`.

## Screenshots
N/A

## What should reviewers focus on?
- 

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [ ] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
