### PR TITLE
display real courses

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -88,6 +88,7 @@ const graphQLMiddlewares = {
   Query: {
     course: publicRoute,
     courses: publicRoute,
+    publicCourses: publicRoute,
     entity: authorizedByAllRoles(),
     entities: authorizedByAllRoles(),
     userById: authorizedByAdmin(),

--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -69,7 +69,10 @@ const courseResolvers = {
       const accessToken = getAccessToken(context.req);
       const role = await authService.getUserRoleByAccessToken(accessToken);
       const attributes = getCourseVisibilityAttributes(role);
-
+      return courseService.getCourses(attributes);
+    },
+    publicCourses: async (): Promise<CourseResponseDTO[]> => {
+      const attributes = getCourseVisibilityAttributes(null);
       return courseService.getCourses(attributes);
     },
   },

--- a/backend/graphql/types/courseType.ts
+++ b/backend/graphql/types/courseType.ts
@@ -52,6 +52,7 @@ const courseType = gql`
   extend type Query {
     course(id: ID!): CourseResponseDTO!
     courses: [CourseResponseDTO!]!
+    publicCourses: [CourseResponseDTO!]!
   }
 
   extend type Mutation {

--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -78,7 +78,7 @@ const refreshDirectionalLink = new RetryLink().split(
       "ResetPassword",
       "Login",
       "Signup_Register",
-      "Courses",
+      "PublicCourses",
     ].includes(operation.operationName),
   authFromLocalLink.concat(httpLink),
   accessTokenInjectionLink.concat(httpLink),

--- a/frontend/src/APIClients/BaseAPIClient.ts
+++ b/frontend/src/APIClients/BaseAPIClient.ts
@@ -73,9 +73,13 @@ const accessTokenInjectionLink = new ApolloLink(
 
 const refreshDirectionalLink = new RetryLink().split(
   (operation) =>
-    ["Refresh", "ResetPassword", "Login", "Signup_Register"].includes(
-      operation.operationName,
-    ),
+    [
+      "Refresh",
+      "ResetPassword",
+      "Login",
+      "Signup_Register",
+      "Courses",
+    ].includes(operation.operationName),
   authFromLocalLink.concat(httpLink),
   accessTokenInjectionLink.concat(httpLink),
 );

--- a/frontend/src/APIClients/queries/CourseQueries.ts
+++ b/frontend/src/APIClients/queries/CourseQueries.ts
@@ -22,6 +22,29 @@ export const COURSES = gql`
   }
 `;
 
+// Same as COURSES but does not require authentication
+export const PUBLIC_COURSES = gql`
+  query PublicCourses {
+    publicCourses {
+      id
+      title
+      description
+      image
+      previewImage
+      modules {
+        id
+        title
+        description
+        image
+        previewImage
+        published
+        lessons
+      }
+      private
+    }
+  }
+`;
+
 export const GET_COURSE = gql`
   query GetCourse($id: ID!) {
     course(id: $id) {

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -24,7 +24,12 @@ const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
   const handleBlur = () => setFocused(false);
   const handleMouseEnter = () => setHovered(true);
   const handleMouseLeave = () => setHovered(false);
-
+  const moduleCount = course.modules?.length || 0;
+  const lessonCount =
+    course.modules?.reduce(
+      (currSum, module) => currSum + (module?.lessons?.length || 0),
+      0,
+    ) || 0;
   const expanded = focused || hovered;
 
   return (
@@ -72,7 +77,7 @@ const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
           <Spacer />
           <Box>
             <Icon as={DocumentIcon} marginTop="-5px" marginRight="5px" />
-            insert course info
+            Modules: {moduleCount} | Lessons: {lessonCount}
           </Box>
         </Flex>
       </Flex>

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -77,7 +77,7 @@ const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
           <Spacer />
           <Box>
             <Icon as={DocumentIcon} marginTop="-5px" marginRight="5px" />
-            Modules: {moduleCount} | Lessons: {lessonCount}
+            {moduleCount} Modules • {lessonCount} Lessons
           </Box>
         </Flex>
       </Flex>

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -16,8 +16,13 @@ import { CourseResponse } from "../../../APIClients/types/CourseClientTypes";
 
 interface CourseCardProps {
   course: CourseResponse;
+  hidden: boolean;
 }
-const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
+
+const CourseCard = ({
+  course,
+  hidden,
+}: CourseCardProps): React.ReactElement => {
   const [focused, setFocused] = useState<boolean>(false);
   const [hovered, setHovered] = useState<boolean>(false);
   const handleFocus = () => setFocused(true);
@@ -60,7 +65,7 @@ const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
         <Flex direction="column" padding="24px" flex={1}>
           <Box>
             <Heading as="h3" size="md" marginBottom="6px">
-              {course.title}
+              {hidden ? "Course Title" : course.title}
             </Heading>
           </Box>
           <Box
@@ -72,12 +77,13 @@ const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
               "-webkit-box-orient": "vertical",
             }}
           >
-            {course.description}
+            {hidden ? "Description..." : course.description}
           </Box>
           <Spacer />
           <Box>
             <Icon as={DocumentIcon} marginTop="-5px" marginRight="5px" />
-            {moduleCount} Modules • {lessonCount} Lessons
+            {hidden ? "N" : moduleCount} Modules • {hidden ? "N" : lessonCount}{" "}
+            Lessons
           </Box>
         </Flex>
       </Flex>

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -12,8 +12,12 @@ import { ReactComponent as DocumentIcon } from "../../../assets/document.svg";
 import { DEFAULT_IMAGE } from "../../../constants/DummyData";
 import RouterLink from "../../common/RouterLink";
 import { COURSE_OVERVIEW_BASE_ROUTE } from "../../../constants/Routes";
+import { CourseResponse } from "../../../APIClients/types/CourseClientTypes";
 
-const CourseCard = (): React.ReactElement => {
+interface CourseCardProps {
+  course: CourseResponse;
+}
+const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
   const [focused, setFocused] = useState<boolean>(false);
   const [hovered, setHovered] = useState<boolean>(false);
   const handleFocus = () => setFocused(true);
@@ -51,7 +55,7 @@ const CourseCard = (): React.ReactElement => {
         <Flex direction="column" padding="24px" flex={1}>
           <Box>
             <Heading as="h3" size="md" marginBottom="6px">
-              insert course title
+              {course.title}
             </Heading>
           </Box>
           <Box
@@ -63,8 +67,7 @@ const CourseCard = (): React.ReactElement => {
               "-webkit-box-orient": "vertical",
             }}
           >
-            Description description description description description
-            description description
+            {course.description}
           </Box>
           <Spacer />
           <Box>

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -1,28 +1,16 @@
 import React, { useState } from "react";
-import {
-  Box,
-  Collapse,
-  Flex,
-  Heading,
-  Icon,
-  Image,
-  Spacer,
-} from "@chakra-ui/react";
-import { ReactComponent as DocumentIcon } from "../../../assets/document.svg";
+import { Box, Collapse, Flex, Heading, Image, Spacer } from "@chakra-ui/react";
 import { DEFAULT_IMAGE } from "../../../constants/DummyData";
 import RouterLink from "../../common/RouterLink";
 import { COURSE_OVERVIEW_BASE_ROUTE } from "../../../constants/Routes";
 import { CourseResponse } from "../../../APIClients/types/CourseClientTypes";
+import ModuleLessonCount from "../ModuleLessonCount";
 
 interface CourseCardProps {
   course: CourseResponse;
-  hidden: boolean;
 }
 
-const CourseCard = ({
-  course,
-  hidden,
-}: CourseCardProps): React.ReactElement => {
+const CourseCard = ({ course }: CourseCardProps): React.ReactElement => {
   const [focused, setFocused] = useState<boolean>(false);
   const [hovered, setHovered] = useState<boolean>(false);
   const handleFocus = () => setFocused(true);
@@ -65,7 +53,7 @@ const CourseCard = ({
         <Flex direction="column" padding="24px" flex={1}>
           <Box>
             <Heading as="h3" size="md" marginBottom="6px">
-              {hidden ? "Course Title" : course.title}
+              {course.title}
             </Heading>
           </Box>
           <Box
@@ -77,13 +65,14 @@ const CourseCard = ({
               "-webkit-box-orient": "vertical",
             }}
           >
-            {hidden ? "Description..." : course.description}
+            {course.description}
           </Box>
           <Spacer />
           <Box>
-            <Icon as={DocumentIcon} marginTop="-5px" marginRight="5px" />
-            {hidden ? "N" : moduleCount} Modules • {hidden ? "N" : lessonCount}{" "}
-            Lessons
+            <ModuleLessonCount
+              moduleCount={moduleCount}
+              lessonCount={lessonCount}
+            />
           </Box>
         </Flex>
       </Flex>

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -1,54 +1,21 @@
 import React, { useContext, useState } from "react";
 import { Flex, Heading, SimpleGrid, VStack } from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
 import AuthContext from "../../contexts/AuthContext";
 import Banner from "../learner/Banner";
 import CourseTabs, { TAB_NAMES } from "../learner/browser/CourseTabs";
 import CourseCard from "../learner/browser/CourseCard";
-import { CourseType } from "../../types/ModuleEditorTypes";
+import { COURSES } from "../../APIClients/queries/CourseQueries";
+import { CourseResponse } from "../../APIClients/types/CourseClientTypes";
 
 const Default = (): React.ReactElement => {
   const { authenticatedUser } = useContext(AuthContext);
 
   const [selectedTab, setSelectedTab] = useState<string>(TAB_NAMES[0]);
 
-  const courses: Array<CourseType> = [
-    {
-      id: "1",
-      title: "Understanding Abuse",
-      description: "A b c...",
-      image: null,
-      previewImage: null,
-      private: false,
-      modules: [],
-    },
-    {
-      id: "2",
-      title: "Understanding Abuse",
-      description: "A b c...",
-      image: null,
-      previewImage: null,
-      private: false,
-      modules: [],
-    },
-    {
-      id: "3",
-      title: "Understanding Abuse",
-      description: "A b c...",
-      image: null,
-      previewImage: null,
-      private: false,
-      modules: [],
-    },
-    {
-      id: "4",
-      title: "Understanding Abuse",
-      description: "A b c...",
-      image: null,
-      previewImage: null,
-      private: false,
-      modules: [],
-    },
-  ]; // TODO fetch courses
+  const { data } = useQuery<{ courses: Array<CourseResponse> }>(COURSES);
+
+  const { courses } = data ?? { courses: [] };
 
   return (
     <Flex direction="column">
@@ -68,8 +35,8 @@ const Default = (): React.ReactElement => {
           width="100%"
           spacing={5}
         >
-          {courses?.map((course) => (
-            <CourseCard key={course.id} />
+          {courses?.map((course: CourseResponse) => (
+            <CourseCard key={course.id} course={course} />
           ))}
         </SimpleGrid>
       </VStack>

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -36,7 +36,11 @@ const Default = (): React.ReactElement => {
           spacing={5}
         >
           {courses?.map((course: CourseResponse) => (
-            <CourseCard key={course.id} course={course} />
+            <CourseCard
+              key={course.id}
+              course={course}
+              hidden={!!authenticatedUser}
+            />
           ))}
         </SimpleGrid>
       </VStack>

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -39,7 +39,7 @@ const Default = (): React.ReactElement => {
             <CourseCard
               key={course.id}
               course={course}
-              hidden={!!authenticatedUser}
+              hidden={!authenticatedUser}
             />
           ))}
         </SimpleGrid>


### PR DESCRIPTION
## Implementation Description
Load in real courses as opposed to dummy data on the courses view page.

## Screenshots
Visual depiction of PR
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/36215359/188338775-b68d60a3-23ee-4189-8b2c-f7939e55ddca.png">


## What should reviewers focus on?
- Make sure that real courses are now being displayed at the root URL (localhost:3000)

## Testing Procedure
- Create some courses, note the title and the description
- Observe that when you go to the root URL this is what is being displayed

## Checklist
- [X] Ensure code follows style guide by running the linters
- [X] I have updated the documentation or deemed it unnecessary
- [X] I have linked the relevant issue in this PR
- [X] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)