### PR TITLE
[RHS-144] - Module Editor: Prevent Losing Progress Modal

### DIFF
--- a/frontend/src/components/common/SaveModal.tsx
+++ b/frontend/src/components/common/SaveModal.tsx
@@ -13,11 +13,8 @@ import {
 
 export interface ModalProps {
   isOpen: boolean;
-  // eslint-disable-next-line @typescript-eslint/ban-types
   onCancel: () => void;
-  // eslint-disable-next-line @typescript-eslint/ban-types
   onDontSave: () => void;
-  // eslint-disable-next-line @typescript-eslint/ban-types
   onSave: () => void;
 }
 
@@ -36,7 +33,7 @@ export const SaveModal = ({
         <ModalBody>
           <Text>
             Are you sure you want to leave with unsaved changes? The new edits
-            will be list.
+            will be lost.
           </Text>
         </ModalBody>
         <ModalFooter>

--- a/frontend/src/components/common/SaveModal.tsx
+++ b/frontend/src/components/common/SaveModal.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable react/forbid-prop-types */
+import React from "react";
+import {
+  Button,
+  Modal as ChakraModal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  Text,
+} from "@chakra-ui/react";
+
+export interface ModalProps {
+  isOpen: boolean;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onCancel: () => void;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onDontSave: () => void;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  onSave: () => void;
+}
+
+export const SaveModal = ({
+  isOpen,
+  onCancel,
+  onDontSave,
+  onSave,
+  ...rest
+}: ModalProps): React.ReactElement => {
+  return (
+    <ChakraModal isCentered onClose={onCancel} isOpen={isOpen} {...rest}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Save changes?</ModalHeader>
+        <ModalBody>
+          <Text>
+            Are you sure you want to leave with unsaved changes? The new edits
+            will be list.
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onSave} mr="1rem">
+            Save
+          </Button>
+          <Button variant="outline" onClick={onDontSave} mr="1rem">
+            Don&apos;t Save
+          </Button>
+          <Button variant="outline" onClick={onCancel}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </ChakraModal>
+  );
+};

--- a/frontend/src/components/module-viewer/SideBar.tsx
+++ b/frontend/src/components/module-viewer/SideBar.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { useParams } from "react-router-dom";
+import { useHistory, useParams } from "react-router-dom";
 import {
   Box,
   Button,
@@ -12,7 +12,6 @@ import {
 } from "@chakra-ui/react";
 import { ChevronLeftIcon, EditIcon } from "@chakra-ui/icons";
 import { useMutation, useQuery } from "@apollo/client";
-import { ReactComponent as SaveIcon } from "../../assets/Save.svg";
 import {
   COURSE_OVERVIEW_BASE_ROUTE,
   MANAGE_COURSES_PAGE,
@@ -43,7 +42,7 @@ import { formatLessonRequest } from "../../utils/lessonUtils";
 import EditModuleModal from "../common/EditModuleModal";
 import EditorTabs from "./EditorTabs";
 import ModuleOverview from "./SideBarModuleOverview";
-import RouterLink from "../common/RouterLink";
+import { SaveModal } from "../common/SaveModal";
 import { GET_COURSE } from "../../APIClients/queries/CourseQueries";
 
 const Sidebar = ({
@@ -59,7 +58,19 @@ const Sidebar = ({
   }: ModuleEditorParams = useParams();
   const moduleIndex = Number(moduleIndexString);
 
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const history = useHistory();
+
+  const {
+    isOpen: isOpenEditModule,
+    onOpen: onOpenEditModule,
+    onClose: onCloseEditModule,
+  } = useDisclosure();
+
+  const {
+    isOpen: isOpenSaveModal,
+    onOpen: onOpenSaveModal,
+    onClose: onCloseSaveModal,
+  } = useDisclosure();
 
   const context: EditorContextType = useContext(EditorContext);
   const { data: courseData, error } = useQuery<{ course: CourseResponse }>(
@@ -173,6 +184,22 @@ const Sidebar = ({
 
   const module = courseData?.course?.modules?.[moduleIndex] as ModuleResponse;
 
+  const onCoursePageRoute = () => {
+    history.push(
+      editable
+        ? MANAGE_COURSES_PAGE
+        : `${COURSE_OVERVIEW_BASE_ROUTE}/${courseID}`,
+    );
+  };
+
+  const onReturnToCoursePageClick = () => {
+    if (Object.values(state.hasChanged).length) {
+      onOpenSaveModal();
+    } else {
+      onCoursePageRoute();
+    }
+  };
+
   return (
     <>
       {module && (
@@ -199,20 +226,17 @@ const Sidebar = ({
                 p="35px"
               >
                 <HStack justify="space-between" align="start">
-                  <RouterLink
-                    to={
-                      editable
-                        ? MANAGE_COURSES_PAGE
-                        : `${COURSE_OVERVIEW_BASE_ROUTE}/${courseID}`
-                    }
-                  >
-                    <ChevronLeftIcon color="white" h={6} w={6} />
-                  </RouterLink>
+                  <Button
+                    variant="md"
+                    leftIcon={<ChevronLeftIcon color="white" h={6} w={6} />}
+                    onClick={onReturnToCoursePageClick}
+                    backgroundColor="transparent"
+                  />
                   {editable && (
                     <Button
                       variant="md"
                       leftIcon={<EditIcon color="white" h={5} w={5} />}
-                      onClick={onOpen}
+                      onClick={onOpenEditModule}
                       backgroundColor="transparent"
                     />
                   )}
@@ -231,23 +255,6 @@ const Sidebar = ({
               <>
                 <EditorTabs onLessonSelected={onLessonSelected} />
                 <Spacer />
-                {Object.values(state.hasChanged).length ? (
-                  <Button
-                    bg="#5FCA89"
-                    color="white"
-                    leftIcon={<SaveIcon />}
-                    borderRadius="0"
-                    pl="35px"
-                    width="100%"
-                    h="55px"
-                    justifyContent="left"
-                    onClick={() => saveChanges(state.hasChanged)}
-                  >
-                    Save Changes
-                  </Button>
-                ) : (
-                  <></>
-                )}
               </>
             ) : (
               <ModuleOverview
@@ -256,10 +263,19 @@ const Sidebar = ({
               />
             )}
           </Flex>
+          <SaveModal
+            isOpen={isOpenSaveModal}
+            onSave={() => {
+              saveChanges(state.hasChanged);
+              onCoursePageRoute();
+            }}
+            onDontSave={onCoursePageRoute}
+            onCancel={onCloseSaveModal}
+          />
           <EditModuleModal
             module={module}
-            isOpen={isOpen}
-            onClose={onClose}
+            isOpen={isOpenEditModule}
+            onClose={onCloseEditModule}
             formatCourseRequest={formatCourseRequest}
           />
         </Box>

--- a/frontend/src/components/module-viewer/SideBar.tsx
+++ b/frontend/src/components/module-viewer/SideBar.tsx
@@ -76,16 +76,17 @@ const Sidebar = ({
     const confirmationMessage = "Some message";
     e.preventDefault();
     e.returnValue = confirmationMessage;
+    return confirmationMessage;
   }, []);
 
-  const cb = useRef<any>(handlePageLeave);
+  const cb = useRef<(e: BeforeUnloadEvent) => string>(handlePageLeave);
 
   useEffect(() => {
     cb.current = handlePageLeave;
   }, [handlePageLeave]);
 
   useEffect(() => {
-    const onUnload = (...args: any[]) => cb.current?.(...args);
+    const onUnload = (e: BeforeUnloadEvent) => cb.current?.(e);
 
     window.addEventListener("beforeunload", onUnload);
 


### PR DESCRIPTION
## Implementation Description
The PR seeks to implement a new mechanism for users to save their made changes on the module editor page when they decide to exit. When users click on the back button to go back to the course overview page, a modal pops up asking if they want their changes saved, unsaved, or canceled. The different behaviors of these choices are documented in the ticket linked to this PR. 

## Screenshots
![image](https://user-images.githubusercontent.com/63923219/188559332-18b21492-7bb3-4e98-b2be-8e7f1a5280e2.png)


## What should reviewers focus on?
- Ensure the modal buttons work as described in the ticket.
- Ensure when no changes are made, the back button successfully routes to the appropriate page.
- Test the functionality for both admin and learners. 

## Testing Procedure
- What test(s) should we run to make sure your code works?
   - What ways could the input be wrong?
   - Is it secure? Could nefarious users access/break it?

## Things to Note
- Additional dependencies/libraries you've added?
- Things you'd want to know when coming back to the code after a few months

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [ ] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)