### PR TITLE
add modal for downloading user stats

### DIFF
--- a/frontend/src/APIClients/queries/UserQueries.ts
+++ b/frontend/src/APIClients/queries/UserQueries.ts
@@ -19,3 +19,9 @@ export const GET_EMAIL_VERIFIED_BY_EMAIL = gql`
     emailVerifiedByEmail(email: $email)
   }
 `;
+
+export const GET_USER_COUNT_BY_TOWN = gql`
+  query GetUserCountByTown($startDate: String, $endDate: String) {
+    userCountByTown(startDate: $startDate, endDate: $endDate)
+  }
+`;

--- a/frontend/src/APIClients/types/UserClientTypes.ts
+++ b/frontend/src/APIClients/types/UserClientTypes.ts
@@ -16,3 +16,8 @@ export type UserResponse = {
   town: string;
   role: Role;
 };
+
+export type UserCountForTown = {
+  town: string;
+  count: number;
+};

--- a/frontend/src/APIClients/types/UserClientTypes.ts
+++ b/frontend/src/APIClients/types/UserClientTypes.ts
@@ -16,8 +16,3 @@ export type UserResponse = {
   town: string;
   role: Role;
 };
-
-export type UserCountForTown = {
-  town: string;
-  count: number;
-};

--- a/frontend/src/components/admin/DatePicker.tsx
+++ b/frontend/src/components/admin/DatePicker.tsx
@@ -1,0 +1,83 @@
+import React, { useState } from "react";
+import { Text, Stack, Select, Input } from "@chakra-ui/react";
+
+type DatePickerProps = {
+  label: string;
+  day: string;
+  setDate: (date: string) => void;
+};
+
+const DatePicker = ({
+  label,
+  day,
+  setDate,
+}: DatePickerProps): React.ReactElement => {
+  enum Months {
+    January = "01",
+    February = "02",
+    March = "03",
+    April = "04",
+    May = "05",
+    June = "06",
+    July = "07",
+    August = "08",
+    September = "09",
+    October = "10",
+    November = "11",
+    December = "12",
+  }
+
+  const [month, setMonth] = useState("");
+  const [year, setYear] = useState("");
+  const [invalidYear, setInvalidYear] = useState(false);
+
+  const updateDate = () => {
+    if (month !== "" && year !== "") {
+      setDate(`${year}/${Months[month as keyof typeof Months]}/${day}`);
+    }
+  };
+
+  const handleYearInput = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const inputYear = event.target.value;
+    setYear(inputYear);
+    setInvalidYear(!Number.isInteger(Number(inputYear)));
+    if (!invalidYear) {
+      updateDate();
+    }
+  };
+
+  const handleMonthInput = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const inputMonth = event.target.value;
+    setMonth(inputMonth);
+    updateDate();
+  };
+
+  return (
+    <Stack direction="column">
+      <Text>{label}</Text>
+      <Stack direction="row">
+        <Select
+          placeholder="Month"
+          size="sm"
+          value={month}
+          onChange={handleMonthInput}
+        >
+          {Object.keys(Months).map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </Select>
+        <Input
+          isInvalid={invalidYear}
+          placeholder="Year"
+          value={year}
+          onChange={handleYearInput}
+          size="sm"
+        />
+      </Stack>
+    </Stack>
+  );
+};
+
+export default DatePicker;

--- a/frontend/src/components/admin/DatePicker.tsx
+++ b/frontend/src/components/admin/DatePicker.tsx
@@ -3,14 +3,20 @@ import { Text, Stack, Select, Input } from "@chakra-ui/react";
 
 type DatePickerProps = {
   label: string;
-  day: string;
-  setDate: (date: string) => void;
+  month: string;
+  year: string;
+  setMonth: (month: string) => void;
+  setYear: (year: string) => void;
+  invalid?: boolean;
 };
 
 const DatePicker = ({
   label,
-  day,
-  setDate,
+  month,
+  year,
+  setMonth,
+  setYear,
+  invalid,
 }: DatePickerProps): React.ReactElement => {
   enum Months {
     January = "01",
@@ -27,29 +33,12 @@ const DatePicker = ({
     December = "12",
   }
 
-  const [month, setMonth] = useState("");
-  const [year, setYear] = useState("");
-  const [invalidYear, setInvalidYear] = useState(false);
-
-  const updateDate = () => {
-    if (month !== "" && year !== "") {
-      setDate(`${year}/${Months[month as keyof typeof Months]}/${day}`);
-    }
-  };
-
   const handleYearInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const inputYear = event.target.value;
-    setYear(inputYear);
-    setInvalidYear(!Number.isInteger(Number(inputYear)));
-    if (!invalidYear) {
-      updateDate();
-    }
+    setYear(event.target.value.replace(/\D/g, ""));
   };
 
   const handleMonthInput = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const inputMonth = event.target.value;
-    setMonth(inputMonth);
-    updateDate();
+    setMonth(Months[event.target.value as keyof typeof Months]);
   };
 
   return (
@@ -58,8 +47,9 @@ const DatePicker = ({
       <Stack direction="row">
         <Select
           placeholder="Month"
+          isInvalid={invalid}
           size="sm"
-          value={month}
+          value={Object.keys(Months)[Number(month) - 1]}
           onChange={handleMonthInput}
         >
           {Object.keys(Months).map((m) => (
@@ -69,7 +59,7 @@ const DatePicker = ({
           ))}
         </Select>
         <Input
-          isInvalid={invalidYear}
+          isInvalid={invalid}
           placeholder="Year"
           value={year}
           onChange={handleYearInput}

--- a/frontend/src/components/admin/DatePicker.tsx
+++ b/frontend/src/components/admin/DatePicker.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text, Stack, Select, Input } from "@chakra-ui/react";
+import { Stack, Select, Input, FormControl, FormLabel } from "@chakra-ui/react";
 
 type DatePickerProps = {
   label: string;
@@ -42,31 +42,34 @@ const DatePicker = ({
   };
 
   return (
-    <Stack direction="column">
-      <Text>{label}</Text>
-      <Stack direction="row">
-        <Select
-          placeholder="Month"
-          isInvalid={invalid}
-          size="sm"
-          value={Object.keys(Months)[Number(month) - 1]}
-          onChange={handleMonthInput}
-        >
-          {Object.keys(Months).map((m) => (
-            <option key={m} value={m}>
-              {m}
-            </option>
-          ))}
-        </Select>
-        <Input
-          isInvalid={invalid}
-          placeholder="Year"
-          value={year}
-          onChange={handleYearInput}
-          size="sm"
-        />
+    <FormControl>
+      <Stack direction="column">
+        <FormLabel>{label}</FormLabel>
+        <Stack direction="row">
+          <Select
+            placeholder="Month"
+            isInvalid={invalid}
+            size="sm"
+            value={Object.keys(Months)[Number(month) - 1]}
+            onChange={handleMonthInput}
+          >
+            {Object.keys(Months).map((m) => (
+              <option key={m} value={m}>
+                {m}
+              </option>
+            ))}
+          </Select>
+          <Input
+            isInvalid={invalid}
+            placeholder="Year"
+            value={year}
+            inputMode="numeric"
+            onChange={handleYearInput}
+            size="sm"
+          />
+        </Stack>
       </Stack>
-    </Stack>
+    </FormControl>
   );
 };
 

--- a/frontend/src/components/admin/DatePicker.tsx
+++ b/frontend/src/components/admin/DatePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Text, Stack, Select, Input } from "@chakra-ui/react";
 
 type DatePickerProps = {

--- a/frontend/src/components/admin/DownloadDataModal.tsx
+++ b/frontend/src/components/admin/DownloadDataModal.tsx
@@ -20,9 +20,7 @@ const DownloadDataModal = ({
   const [startYear, setStartYear] = useState("");
   const [endMonth, setEndMonth] = useState("");
   const [endYear, setEndYear] = useState("");
-  const [getCounts, { loading, error, data }] = useLazyQuery(
-    GET_USER_COUNT_BY_TOWN,
-  );
+  const [getCounts, { loading }] = useLazyQuery(GET_USER_COUNT_BY_TOWN);
   const [downloadEnabled, setDownloadEnabled] = useState(true);
   const [rangeInvalid, setRangeInvalid] = useState(false);
 
@@ -52,7 +50,7 @@ const DownloadDataModal = ({
       setDownloadEnabled(true);
       setRangeInvalid(false);
     }
-  });
+  }, [radioOption, startMonth, startYear, endMonth, endYear]);
 
   const onDownloadConfirm = async () => {
     const startDS = new Date(Number(startYear), Number(startMonth) - 1, 1);

--- a/frontend/src/components/admin/DownloadDataModal.tsx
+++ b/frontend/src/components/admin/DownloadDataModal.tsx
@@ -1,0 +1,116 @@
+import React, { useState } from "react";
+import { useQuery } from "@apollo/client";
+import {
+  Box,
+  Text,
+  Radio,
+  RadioGroup,
+  Stack,
+  Select,
+  Input,
+} from "@chakra-ui/react";
+import { UserCountForTown } from "../../APIClients/types/UserClientTypes";
+import { Modal } from "../common/Modal";
+import { GET_USER_COUNT_BY_TOWN } from "../../APIClients/queries/UserQueries";
+
+const DatePicker = ({ label }: { label: string }): React.ReactElement => {
+  const [month, setMonth] = useState("");
+  const [year, setYear] = useState("");
+
+  const months = [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ];
+  return (
+    <Stack direction="column">
+      <Text>{label}</Text>
+      <Stack direction="row">
+        <Select
+          placeholder="Month"
+          size="sm"
+          value={month}
+          onChange={(event) => setMonth(event.target.value)}
+        >
+          {months.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </Select>
+        <Input
+          placeholder="Year"
+          value={year}
+          onChange={(event) => setYear(event.target.value)}
+          size="sm"
+        />
+      </Stack>
+    </Stack>
+  );
+};
+
+type DownloadProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+const DownloadDataModal = ({
+  isOpen,
+  onClose,
+}: DownloadProps): React.ReactElement => {
+  const [timeframe, setTimeframe] = useState("1");
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
+  const { data, loading, error } = useQuery<{
+    userCounts: Array<UserCountForTown>;
+  }>(GET_USER_COUNT_BY_TOWN, {
+    variables: { startDate, endDate },
+  });
+  const { userCounts } = data ?? { userCounts: [] };
+
+  const onDownloadConfirm = () => {
+    console.log(userCounts);
+    // download as CSV
+  };
+
+  return (
+    <Modal
+      size="2xl"
+      header="Pick timeframe to download data"
+      onConfirm={onDownloadConfirm}
+      onCancel={onClose}
+      isOpen={isOpen}
+    >
+      <RadioGroup onChange={setTimeframe} value={timeframe}>
+        <Stack orientation="vertical">
+          <Box borderWidth="1px" w="100%" padding="0.5rem" marginBottom="5px">
+            <Radio spacing="1rem" value="1">
+              <Text as="b">Download all data</Text>
+            </Radio>
+          </Box>
+          <Box borderWidth="1px" w="100%" padding="0.5rem" marginBottom="5px">
+            <Radio spacing="1rem" value="2">
+              <Text as="b">Download from selected range</Text>
+            </Radio>
+            <Stack direction="row" marginLeft="2rem" marginTop="0.5rem">
+              <DatePicker label="Start Date" />
+              <DatePicker label="End Date" />
+            </Stack>
+          </Box>
+        </Stack>
+      </RadioGroup>
+    </Modal>
+  );
+};
+
+export default DownloadDataModal;

--- a/frontend/src/components/admin/DownloadDataModal.tsx
+++ b/frontend/src/components/admin/DownloadDataModal.tsx
@@ -22,11 +22,6 @@ const DownloadDataModal = ({
   const [endYear, setEndYear] = useState("");
   const [getCounts, { loading, error, data }] = useLazyQuery(
     GET_USER_COUNT_BY_TOWN,
-    {
-      onCompleted: () => {
-        console.log(data);
-      },
-    },
   );
   const [downloadEnabled, setDownloadEnabled] = useState(true);
   const [rangeInvalid, setRangeInvalid] = useState(false);
@@ -62,13 +57,15 @@ const DownloadDataModal = ({
   const onDownloadConfirm = async () => {
     const startDS = new Date(Number(startYear), Number(startMonth) - 1, 1);
     const endDS = new Date(Number(endYear), Number(endMonth), 0);
-    const startDate = startDS.toLocaleDateString("en-ZA");
-    const endDate = endDS.toLocaleDateString("en-ZA");
+    let startDate = startDS.toLocaleDateString("en-ZA");
+    let endDate = endDS.toLocaleDateString("en-ZA");
 
-    const something = await getCounts({ variables: { startDate, endDate } });
-    console.log(something);
-
-    const csvString = data?.userCountByTown
+    if (radioOption === "1") {
+      startDate = "";
+      endDate = "";
+    }
+    const counts = await getCounts({ variables: { startDate, endDate } });
+    const csvString = counts.data.userCountByTown
       .replaceAll(/{|}/g, "")
       .replaceAll(",", "\n")
       .replaceAll(":", ",");

--- a/frontend/src/components/admin/DownloadDataModal.tsx
+++ b/frontend/src/components/admin/DownloadDataModal.tsx
@@ -1,96 +1,10 @@
 import React, { useState } from "react";
 import { useQuery } from "@apollo/client";
-import {
-  Box,
-  Text,
-  Radio,
-  RadioGroup,
-  Stack,
-  Select,
-  Input,
-} from "@chakra-ui/react";
+import { Box, Text, Radio, RadioGroup, Stack } from "@chakra-ui/react";
 import { Modal } from "../common/Modal";
 import { GET_USER_COUNT_BY_TOWN } from "../../APIClients/queries/UserQueries";
 import { downloadCSV } from "../../utils/CSVUtils";
-
-type DatePickerProps = {
-  label: string;
-  day: string;
-  setDate: (date: string) => void;
-};
-
-const DatePicker = ({
-  label,
-  day,
-  setDate,
-}: DatePickerProps): React.ReactElement => {
-  enum Months {
-    January = "01",
-    February = "02",
-    March = "03",
-    April = "04",
-    May = "05",
-    June = "06",
-    July = "07",
-    August = "08",
-    September = "09",
-    October = "10",
-    November = "11",
-    December = "12",
-  }
-
-  const [month, setMonth] = useState("");
-  const [year, setYear] = useState("");
-  const [invalidYear, setInvalidYear] = useState(false);
-
-  const updateDate = () => {
-    if (month !== "" && year !== "") {
-      setDate(`${year}/${Months[month as keyof typeof Months]}/${day}`);
-    }
-  };
-
-  const handleYearInput = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const inputYear = event.target.value;
-    setYear(inputYear);
-    setInvalidYear(!Number.isInteger(Number(inputYear)));
-    if (!invalidYear) {
-      updateDate();
-    }
-  };
-
-  const handleMonthInput = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const inputMonth = event.target.value;
-    setMonth(inputMonth);
-    updateDate();
-  };
-
-  return (
-    <Stack direction="column">
-      <Text>{label}</Text>
-      <Stack direction="row">
-        <Select
-          placeholder="Month"
-          size="sm"
-          value={month}
-          onChange={handleMonthInput}
-        >
-          {Object.keys(Months).map((m) => (
-            <option key={m} value={m}>
-              {m}
-            </option>
-          ))}
-        </Select>
-        <Input
-          isInvalid={invalidYear}
-          placeholder="Year"
-          value={year}
-          onChange={handleYearInput}
-          size="sm"
-        />
-      </Stack>
-    </Stack>
-  );
-};
+import DatePicker from "./DatePicker";
 
 type DownloadProps = {
   isOpen: boolean;

--- a/frontend/src/components/admin/DownloadDataModal.tsx
+++ b/frontend/src/components/admin/DownloadDataModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { useQuery } from "@apollo/client";
+import React, { useState, useEffect } from "react";
+import { useLazyQuery } from "@apollo/client";
 import { Box, Text, Radio, RadioGroup, Stack } from "@chakra-ui/react";
 import { Modal } from "../common/Modal";
 import { GET_USER_COUNT_BY_TOWN } from "../../APIClients/queries/UserQueries";
@@ -15,53 +15,140 @@ const DownloadDataModal = ({
   isOpen,
   onClose,
 }: DownloadProps): React.ReactElement => {
-  const [timeframe, setTimeframe] = useState("1");
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const [radioOption, setRadioOption] = useState("1");
+  const [startMonth, setStartMonth] = useState("");
+  const [startYear, setStartYear] = useState("");
+  const [endMonth, setEndMonth] = useState("");
+  const [endYear, setEndYear] = useState("");
+  const [getCounts, { loading, error, data }] = useLazyQuery(
+    GET_USER_COUNT_BY_TOWN,
+    {
+      onCompleted: () => {
+        console.log(data);
+      },
+    },
+  );
+  const [downloadEnabled, setDownloadEnabled] = useState(true);
+  const [rangeInvalid, setRangeInvalid] = useState(false);
 
-  const { data: counts } = useQuery(GET_USER_COUNT_BY_TOWN, {
-    variables: { startDate, endDate },
+  useEffect(() => {
+    if (radioOption === "2") {
+      if (
+        startMonth === "" ||
+        startYear === "" ||
+        endMonth === "" ||
+        endYear === "" ||
+        startYear.length !== 4 ||
+        endYear.length !== 4
+      ) {
+        setDownloadEnabled(false);
+        setRangeInvalid(false);
+      } else {
+        setDownloadEnabled(true);
+        const startDS = new Date(Number(startYear), Number(startMonth) - 1, 1);
+        const endDS = new Date(Number(endYear), Number(endMonth), 0);
+        if (startDS > endDS) {
+          setRangeInvalid(true);
+        } else {
+          setRangeInvalid(false);
+        }
+      }
+    } else {
+      setDownloadEnabled(true);
+      setRangeInvalid(false);
+    }
   });
 
-  const onDownloadConfirm = () => {
-    const startDS = new Date(startDate);
-    const endDS = new Date(endDate);
-    if (startDS > endDS) {
-      console.log("date range invalid");
-      return;
-    }
-    if (counts) {
-      const csvString = counts.userCountByTown
-        .replaceAll(/{|}/g, "")
-        .replaceAll(",", "\n")
-        .replaceAll(":", ",");
-      downloadCSV(csvString, "user_counts_export.csv");
-    }
+  const onDownloadConfirm = async () => {
+    const startDS = new Date(Number(startYear), Number(startMonth) - 1, 1);
+    const endDS = new Date(Number(endYear), Number(endMonth), 0);
+    const startDate = startDS.toLocaleDateString("en-ZA");
+    const endDate = endDS.toLocaleDateString("en-ZA");
+
+    const something = await getCounts({ variables: { startDate, endDate } });
+    console.log(something);
+
+    const csvString = data?.userCountByTown
+      .replaceAll(/{|}/g, "")
+      .replaceAll(",", "\n")
+      .replaceAll(":", ",");
+    downloadCSV(csvString, "user_counts_export.csv");
   };
 
+  const boxProps = {
+    borderWidth: "1px",
+    w: "100%",
+    padding: "1rem",
+  };
+  const radioProps = { spacing: "1rem", w: "100%" };
   return (
     <Modal
       size="2xl"
       header="Pick timeframe to download data"
+      confirmText={loading ? "Downloading..." : "Download"}
+      canSubmit={downloadEnabled && !rangeInvalid}
       onConfirm={onDownloadConfirm}
-      onCancel={onClose}
+      onCancel={() => {
+        setRadioOption("1");
+        setStartMonth("");
+        setStartYear("");
+        setEndMonth("");
+        setEndYear("");
+        setRangeInvalid(false);
+        onClose();
+      }}
       isOpen={isOpen}
     >
-      <RadioGroup onChange={setTimeframe} value={timeframe}>
+      <RadioGroup
+        onChange={setRadioOption}
+        value={radioOption}
+        colorScheme="purple"
+      >
         <Stack orientation="vertical">
-          <Box borderWidth="1px" w="100%" padding="0.5rem" marginBottom="5px">
-            <Radio spacing="1rem" value="1" w="100%">
+          <Box {...boxProps}>
+            <Radio value="1" {...radioProps}>
               <Text as="b">Download all data</Text>
             </Radio>
           </Box>
-          <Box borderWidth="1px" w="100%" padding="0.5rem" marginBottom="5px">
-            <Radio spacing="1rem" value="2" w="100%">
+          <Box
+            {...boxProps}
+            onClick={() => {
+              setRadioOption("2");
+            }}
+          >
+            <Radio value="2" {...radioProps}>
               <Text as="b">Download from selected range</Text>
             </Radio>
             <Stack direction="row" marginLeft="2rem" marginTop="0.5rem">
-              <DatePicker label="Start Date" day="01" setDate={setStartDate} />
-              <DatePicker label="End Date" day="31" setDate={setEndDate} />
+              <DatePicker
+                label="Start Date"
+                month={startMonth}
+                year={startYear}
+                setMonth={setStartMonth}
+                setYear={setStartYear}
+                invalid={rangeInvalid}
+              />
+              <DatePicker
+                label="End Date"
+                month={endMonth}
+                year={endYear}
+                setMonth={setEndMonth}
+                setYear={setEndYear}
+                invalid={rangeInvalid}
+              />
             </Stack>
+            {rangeInvalid ? (
+              <Text
+                marginLeft="2rem"
+                marginTop="0.5rem"
+                color="red"
+                fontSize="sm"
+              >
+                Please enter a valid date range
+              </Text>
+            ) : (
+              <></>
+            )}
           </Box>
         </Stack>
       </RadioGroup>

--- a/frontend/src/components/admin/DownloadDataModal.tsx
+++ b/frontend/src/components/admin/DownloadDataModal.tsx
@@ -80,7 +80,8 @@ const DownloadDataModal = ({
     <Modal
       size="2xl"
       header="Pick timeframe to download data"
-      confirmText={loading ? "Downloading..." : "Download"}
+      confirmText="Download"
+      confirmIsLoading={loading}
       canSubmit={downloadEnabled && !rangeInvalid}
       onConfirm={onDownloadConfirm}
       onCancel={() => {

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -22,6 +22,7 @@ export interface ModalProps {
   bodyText?: string;
   cancelText?: string;
   confirmText?: string;
+  confirmIsLoading?: boolean;
   spreadButtons?: boolean;
   canSubmit?: boolean;
   size?: string;
@@ -36,6 +37,7 @@ export const Modal = ({
   bodyText,
   cancelText = "Cancel",
   confirmText = "Confirm",
+  confirmIsLoading,
   spreadButtons = false,
   canSubmit = true,
   children,
@@ -52,7 +54,12 @@ export const Modal = ({
           {children}
         </ModalBody>
         <ModalFooter>
-          <Button disabled={!canSubmit} onClick={onConfirm} mr="1rem">
+          <Button
+            disabled={!canSubmit}
+            onClick={onConfirm}
+            isLoading={confirmIsLoading}
+            mr="1rem"
+          >
             {confirmText}
           </Button>
           {spreadButtons && <Spacer />}

--- a/frontend/src/components/pages/ManageUsersPage.tsx
+++ b/frontend/src/components/pages/ManageUsersPage.tsx
@@ -1,11 +1,19 @@
 import React, { useState } from "react";
-import { Box, Button, Flex, HStack, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Flex,
+  HStack,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
 import { DownloadIcon, SearchIcon } from "@chakra-ui/icons";
 import { UserResponse } from "../../APIClients/types/UserClientTypes";
 import { AdminPage } from "../../types/AdminDashboardTypes";
 import UserCard from "../admin/UserCard";
 import SideBar from "../admin/SideBar";
 import SearchUsersBar from "../admin/SearchUsersBar";
+import DownloadDataModal from "../admin/DownloadDataModal";
 
 const NoUserSelectedCard = (): React.ReactElement => {
   return (
@@ -27,52 +35,56 @@ const NoUserSelectedCard = (): React.ReactElement => {
 
 const ManageUsersPage = (): React.ReactElement => {
   const [spotlightedUser, setSpotlightedUser] = useState<UserResponse | null>();
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
-    <Flex h="100vh">
-      <SideBar currentPage={AdminPage.ManageUsers} />
-      <Box flex="1">
-        <Flex
-          my={6}
-          // px instead of mx to extend border completely in container
-          px={9}
-          pb={6}
-          justify="space-between"
-          borderBottom="1px"
-          borderColor="background.lightgrey"
-        >
-          <HStack>
-            <Text variant="display-lg" mr={9}>
-              Users
+    <>
+      <Flex h="100vh">
+        <SideBar currentPage={AdminPage.ManageUsers} />
+        <Box flex="1">
+          <Flex
+            my={6}
+            // px instead of mx to extend border completely in container
+            px={9}
+            pb={6}
+            justify="space-between"
+            borderBottom="1px"
+            borderColor="background.lightgrey"
+          >
+            <HStack>
+              <Text variant="display-lg" mr={9}>
+                Users
+              </Text>
+              <SearchUsersBar
+                onUserSelect={(user: UserResponse) => setSpotlightedUser(user)}
+              />
+            </HStack>
+            <Button variant="md" leftIcon={<DownloadIcon />} onClick={onOpen}>
+              Download Data
+            </Button>
+          </Flex>
+          <Box px={9}>
+            <Text variant="heading" mb={2}>
+              User Information
             </Text>
-            <SearchUsersBar
-              onUserSelect={(user: UserResponse) => setSpotlightedUser(user)}
-            />
-          </HStack>
-          <Button variant="md" leftIcon={<DownloadIcon />}>
-            Download Data
-          </Button>
-        </Flex>
-        <Box px={9}>
-          <Text variant="heading" mb={2}>
-            User Information
-          </Text>
-          {spotlightedUser ? (
-            <UserCard
-              id={spotlightedUser.id}
-              firstName={spotlightedUser.firstName}
-              lastName={spotlightedUser.lastName}
-              role={spotlightedUser.role}
-              email={spotlightedUser.email}
-              town={spotlightedUser.town}
-              onUserSelect={(user: UserResponse) => setSpotlightedUser(user)}
-            />
-          ) : (
-            <NoUserSelectedCard />
-          )}
+            {spotlightedUser ? (
+              <UserCard
+                id={spotlightedUser.id}
+                firstName={spotlightedUser.firstName}
+                lastName={spotlightedUser.lastName}
+                role={spotlightedUser.role}
+                email={spotlightedUser.email}
+                town={spotlightedUser.town}
+                onUserSelect={(user: UserResponse) => setSpotlightedUser(user)}
+              />
+            ) : (
+              <NoUserSelectedCard />
+            )}
+          </Box>
         </Box>
-      </Box>
-    </Flex>
+      </Flex>
+      <DownloadDataModal isOpen={isOpen} onClose={onClose} />
+    </>
   );
 };
 


### PR DESCRIPTION
## Implementation Description
Added a modal for downloading and added the date pickers as a separate component. The apollo hook used is the `useLazyQuery` hook since we only want to query the data when the user clicks download.

## Screenshots
- Downloading is disabled until a complete date range is provided OR `download all data` is selected
- An invalid date range shows an error
- Non numeric characters do not appear in the year input

![Screen Shot 2022-09-28 at 10 45 12 PM](https://user-images.githubusercontent.com/21024100/192927348-9e8d7087-9b83-4c19-b867-64de6a03a1d2.png)
![Screen Shot 2022-09-28 at 10 45 20 PM](https://user-images.githubusercontent.com/21024100/192927349-a4ae7dbf-e7c0-4733-8e96-01bea2b26ec6.png)
![Screen Shot 2022-09-28 at 10 45 39 PM](https://user-images.githubusercontent.com/21024100/192927352-2c59818e-2a56-48bd-a036-1ae6164cf8be.png)


## What should reviewers focus on?
- Testing

## Testing Procedure
- Follow the issue #137 for info on what the expected behaviour should be.
- Test that download button is only disabled if you are selecting specific date ranges, but have not provided all date range info
- Test that an error shows up if the start date is later than the end date
- Test that closing the modal and returning to it will start in a fresh state

## Things to Note
- Things you'd want to know when coming back to the code after a few months
> Note: Instead of an x button to exit the modal, there's a cancel button. This was done so that the existing modal component could be reused. Hopefully this doesn't make the user experience significantly different.

## Checklist
- [x] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [x] I have linked the relevant issue in this PR
- [ ] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)