### PR TITLE
fix

### DIFF
--- a/frontend/src/components/module-viewer/EditorTabs.tsx
+++ b/frontend/src/components/module-viewer/EditorTabs.tsx
@@ -45,7 +45,7 @@ const EditorTabs = ({
       <TabPanel
         p="0"
         pb="200px"
-        height="100%"
+        height="80%"
         overflowY="auto"
         className="tabScroll"
       >


### PR DESCRIPTION
## Implementation Description

Resolved <https://github.com/uwblueprint/rowan-house/issues/236>

Tab panel would take too much space, overflowing onto the tab list. This would cause the tab list to be pushed up and disappear. Made sure tab panel can only take up 80% of space.

https://user-images.githubusercontent.com/36215359/193434043-955d47b5-5cb9-4250-a228-dcc5acb22109.mov


## What should reviewers focus on?
- Observe that after creating as many lessons as you want the tablist doesn't disappear (the Overview/ Components buttons)

## Checklist
- [X] Ensure code follows style guide by running the linters
- [X] I have updated the documentation or deemed it unnecessary
- [X] I have linked the relevant issue in this PR
- [X] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)