### PR TITLE
course support for images

### DIFF
--- a/backend/graphql/index.ts
+++ b/backend/graphql/index.ts
@@ -100,7 +100,7 @@ const graphQLMiddlewares = {
     createCourse: authorizedByAdmin(),
     updateCourse: authorizedByAdmin(),
     deleteCourse: authorizedByAdmin(),
-    uploadModuleImage: authorizedByAdmin(),
+    uploadImage: authorizedByAdmin(),
     createUser: authorizedByAdmin(),
     updateUser: authorizedByAdmin(),
     updateUserRole: authorizeRoleChange("id"),

--- a/backend/graphql/resolvers/courseResolvers.ts
+++ b/backend/graphql/resolvers/courseResolvers.ts
@@ -102,7 +102,7 @@ const courseResolvers = {
     ): Promise<string> => {
       return courseService.deleteCourse(id);
     },
-    uploadModuleImage: async (
+    uploadImage: async (
       _req: undefined,
       { file }: { file: Promise<FileUpload> },
     ): Promise<UploadedImage> => {

--- a/backend/graphql/types/courseType.ts
+++ b/backend/graphql/types/courseType.ts
@@ -72,7 +72,7 @@ const courseType = gql`
       file: Upload
     ): CourseResponseDTO
     deleteCourse(id: ID!): ID
-    uploadModuleImage(file: Upload): ModuleImageResponseDTO
+    uploadImage(file: Upload): ModuleImageResponseDTO
   }
 `;
 

--- a/frontend/src/APIClients/mutations/CourseMutations.ts
+++ b/frontend/src/APIClients/mutations/CourseMutations.ts
@@ -50,7 +50,7 @@ export const DELETE_COURSE = gql`
 
 export const UPLOAD_IMAGE = gql`
   mutation UploadImage($file: Upload) {
-    uploadModuleImage(file: $file) {
+    uploadImage(file: $file) {
       image
       path
     }

--- a/frontend/src/components/admin/CoursePreview.tsx
+++ b/frontend/src/components/admin/CoursePreview.tsx
@@ -124,6 +124,7 @@ const CoursePreview = ({ course }: CoursePreviewProps): React.ReactElement => {
               <ModulePreview
                 key={module.id}
                 courseId={course.id}
+                coursePreviewImage={course.previewImage}
                 module={module}
                 index={index}
                 formatCourseRequest={formatCourseRequest}

--- a/frontend/src/components/admin/EditCourseModal.tsx
+++ b/frontend/src/components/admin/EditCourseModal.tsx
@@ -1,7 +1,7 @@
-import { Box, VStack } from "@chakra-ui/react";
+import { Box, Flex, Text, VStack } from "@chakra-ui/react";
 import React, { useState } from "react";
 import { useMutation } from "@apollo/client";
-
+import { DEFAULT_IMAGE } from "../../constants/DummyData";
 import { TextInput } from "../common/TextInput";
 import { Modal } from "../common/Modal";
 import { SwitchInput } from "../common/SwitchInput";
@@ -10,8 +10,10 @@ import { CourseResponse } from "../../APIClients/types/CourseClientTypes";
 import {
   CREATE_COURSE,
   UPDATE_COURSE,
+  UPLOAD_IMAGE,
 } from "../../APIClients/mutations/CourseMutations";
 import { COURSES } from "../../APIClients/queries/CourseQueries";
+import { ReactComponent as ImageIcon } from "../../assets/image_white_outline.svg";
 
 export interface EditCourseModalProps {
   onClose: () => void;
@@ -29,6 +31,11 @@ const EditCourseModal = ({
   const [title, setTitle] = useState(course?.title ?? "");
   const [description, setDescription] = useState(course?.description ?? "");
   const [isPrivate, setIsPrivate] = useState(course?.private ?? false);
+  const [isHover, setIsHover] = useState<boolean>();
+  const [previewImage, setPreviewImage] = useState<string | undefined>();
+  const [previewImagePath, setPreviewImagePath] = useState<
+    string | undefined
+  >();
 
   const [updateCourse] = useMutation<CourseResponse>(
     UPDATE_COURSE,
@@ -39,17 +46,50 @@ const EditCourseModal = ({
     refetchQueries,
   );
 
+  const [uploadImage] = useMutation(UPLOAD_IMAGE);
+
   const onCreateCourse = () => {
-    const newCourse = { title, description, private: isPrivate };
+    const newCourse = {
+      title,
+      description,
+      private: isPrivate,
+      previewImage,
+      image: previewImagePath,
+    };
     createCourse({ variables: { course: newCourse } });
     onClose();
   };
 
+  const inputFile = React.useRef<HTMLInputElement>(null);
+
+  const openFileBrowser = () => {
+    if (inputFile.current) {
+      inputFile.current.click();
+    }
+  };
+
+  const fileChanged = async (e: { target: HTMLInputElement }) => {
+    if (e.target.files) {
+      const fileSize = e.target.files[0].size / 1024 / 1024;
+      if (fileSize > 5) {
+        // eslint-disable-next-line no-alert
+        window.alert("Your file exceeds 5MB. Upload a smaller file.");
+      } else {
+        const imageUploadResult = await uploadImage({
+          variables: { file: e.target.files[0] },
+        });
+        const result = imageUploadResult.data.uploadImage ?? null;
+        setPreviewImage(result?.image ?? undefined);
+        setPreviewImagePath(result?.path ?? undefined);
+      }
+    }
+  };
+
   const onUpdateCourse = () => {
     if (course) {
-      const { image, previewImage, modules } = course;
+      const { modules } = course;
       const newCourse = {
-        image,
+        image: previewImagePath,
         previewImage,
         modules,
         title,
@@ -71,27 +111,72 @@ const EditCourseModal = ({
       onCancel={onClose}
       isOpen={isOpen}
     >
-      <VStack>
-        <TextInput
-          label="Course Name:"
-          defaultValue={title}
-          onChange={setTitle}
-          isRequired
-        />
-        <TextArea
-          label="Course Description:"
-          defaultValue={description}
-          onChange={setDescription}
-          isRequired
-        />
-        <SwitchInput
-          enabledName="Public"
-          disabledName="Private"
-          isEnabled={!isPrivate}
-          onChange={(val) => setIsPrivate(!val)}
-        />
-        <Box width={8} />
-      </VStack>
+      <Flex>
+        <VStack flex="1" pr="1rem">
+          <Box
+            borderRadius=".5rem"
+            onMouseEnter={() => setIsHover(true)}
+            onMouseLeave={() => setIsHover(false)}
+            _hover={{
+              background: "black",
+              opacity: 0.9,
+            }}
+            cursor="pointer"
+            onClick={openFileBrowser}
+          >
+            <Flex
+              backgroundImage={previewImage ?? DEFAULT_IMAGE}
+              backgroundPosition="center"
+              h="214px"
+              w="214px"
+              bgRepeat="no-repeat"
+              direction="column"
+              backgroundSize="cover"
+              opacity="1"
+              justifyContent="center"
+              borderRadius=".5rem"
+              alignItems="center"
+            >
+              <input
+                type="file"
+                style={{ display: "none" }}
+                ref={inputFile}
+                onChange={fileChanged}
+                accept="image/*"
+              />
+              {isHover && (
+                <>
+                  <ImageIcon color="white" style={{ marginBottom: "1rem" }} />
+                  <Text variant="caption" color="white">
+                    Upload image
+                  </Text>
+                </>
+              )}
+            </Flex>
+          </Box>
+          <SwitchInput
+            enabledName="Public"
+            disabledName="Private"
+            isEnabled={!isPrivate}
+            onChange={(val) => setIsPrivate(!val)}
+          />
+        </VStack>
+        <VStack flex="1">
+          <TextInput
+            label="Course Name:"
+            defaultValue={title}
+            onChange={setTitle}
+            isRequired
+          />
+          <TextArea
+            label="Course Description:"
+            defaultValue={description}
+            onChange={setDescription}
+            isRequired
+          />
+          <Box width={8} />
+        </VStack>
+      </Flex>
     </Modal>
   );
 };

--- a/frontend/src/components/admin/ModulePreview.tsx
+++ b/frontend/src/components/admin/ModulePreview.tsx
@@ -37,6 +37,7 @@ interface ModulePreviewProps {
   module: ModuleResponse;
   courseId: string;
   index: number;
+  coursePreviewImage: string | null;
   formatCourseRequest: (
     index: number,
     module?: ModuleRequest,
@@ -50,6 +51,7 @@ const ModulePreview = ({
   courseId,
   index,
   formatCourseRequest,
+  coursePreviewImage,
 }: ModulePreviewProps): React.ReactElement => {
   const EDIT_MODULE_ROUTE = buildEditModuleRoute(courseId, index);
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -83,7 +85,7 @@ const ModulePreview = ({
     >
       <Link href={EDIT_MODULE_ROUTE}>
         <Image
-          src={previewImage ?? DEFAULT_IMAGE}
+          src={previewImage ?? coursePreviewImage ?? DEFAULT_IMAGE}
           alt="module-preview"
           objectFit="cover"
           height="160px"

--- a/frontend/src/components/common/EditModuleModal.tsx
+++ b/frontend/src/components/common/EditModuleModal.tsx
@@ -102,7 +102,7 @@ const EditModuleModal = ({
         const imageUploadResult = await uploadImage({
           variables: { file: e.target.files[0] },
         });
-        const result = imageUploadResult.data.uploadModuleImage ?? null;
+        const result = imageUploadResult.data.uploadImage ?? null;
         setPreviewImage(result?.image ?? undefined);
         setPreviewImagePath(result?.path ?? undefined);
       }

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -101,7 +101,7 @@ const CourseCard = ({
       >
         <Collapse startingHeight="120px" endingHeight="105px" in={expanded}>
           <Image
-            src={DEFAULT_IMAGE}
+            src={course.previewImage || DEFAULT_IMAGE}
             alt="course-preview"
             width="100%"
             height="100%"

--- a/frontend/src/components/module-viewer/ModuleCompleted.tsx
+++ b/frontend/src/components/module-viewer/ModuleCompleted.tsx
@@ -59,6 +59,7 @@ const ModuleCompleted = (): React.ReactElement => {
         </Text>
         <UpNext
           courseID={courseID}
+          courseImage={courseData?.course?.previewImage}
           moduleIndex={moduleIndex}
           modules={course.modules}
         />

--- a/frontend/src/components/module-viewer/NextModuleCard.tsx
+++ b/frontend/src/components/module-viewer/NextModuleCard.tsx
@@ -11,6 +11,7 @@ interface NextModuleStatusProps {
 }
 interface NextModuleCardProps {
   courseID: string;
+  courseImage: string | null; // used in case of module image not existing
   nextModuleIndex: number;
   nextModuleProgress: ModuleProgress | undefined;
   modules: ModuleType[];
@@ -54,6 +55,7 @@ const NextModuleCard = ({
   nextModuleIndex,
   nextModuleProgress,
   modules,
+  courseImage,
 }: NextModuleCardProps): React.ReactElement => {
   const [hovered, setHovered] = useState<boolean>(false);
   const handleMouseEnter = () => setHovered(true);
@@ -81,7 +83,7 @@ const NextModuleCard = ({
         padding="1em"
       >
         <Image
-          src={nextModuleData.image || DEFAULT_IMAGE}
+          src={nextModuleData.image ?? courseImage ?? DEFAULT_IMAGE}
           alt="course-preview"
           width="5em"
           height="5em"

--- a/frontend/src/components/module-viewer/SideBar.tsx
+++ b/frontend/src/components/module-viewer/SideBar.tsx
@@ -250,7 +250,11 @@ const Sidebar = ({
               <Flex
                 h="240px"
                 backgroundPosition="center"
-                backgroundImage={module?.previewImage ?? DEFAULT_IMAGE}
+                backgroundImage={
+                  module?.previewImage ??
+                  courseData?.course?.previewImage ??
+                  DEFAULT_IMAGE
+                }
                 backgroundSize="cover"
                 bgRepeat="no-repeat"
                 opacity="1"

--- a/frontend/src/components/module-viewer/UpNext.tsx
+++ b/frontend/src/components/module-viewer/UpNext.tsx
@@ -13,12 +13,14 @@ import NextModuleCard from "./NextModuleCard";
 
 interface UpNextProps {
   courseID: string;
+  courseImage: string | null; // used in case of moduleImage not existing
   moduleIndex: number;
   modules: ModuleType[];
 }
 
 const UpNext = ({
   courseID,
+  courseImage,
   moduleIndex,
   modules,
 }: UpNextProps): React.ReactElement => {
@@ -67,6 +69,7 @@ const UpNext = ({
       {moduleProgressData ? (
         <NextModuleCard
           courseID={courseID}
+          courseImage={courseImage}
           nextModuleIndex={nextModuleIndex}
           nextModuleProgress={nextModuleProgress}
           modules={modules}

--- a/frontend/src/components/pages/CourseOverview.tsx
+++ b/frontend/src/components/pages/CourseOverview.tsx
@@ -154,7 +154,7 @@ const CourseOverview = (): React.ReactElement => {
       >
         <Box flex="2" maxHeight="75%">
           <Image
-            src={courseData?.image || DEFAULT_IMAGE}
+            src={courseData?.course?.previewImage || DEFAULT_IMAGE}
             alt="Course Img"
             width="100%"
             height="100%"


### PR DESCRIPTION
## Implementation Description
You can now add images to courses themselves, and they are the default images for the course modules if there are no course module images set

## Screenshots
Visual depiction of PR

https://user-images.githubusercontent.com/36215359/194804032-8b787456-3df0-4341-aed3-2c40d1dc7ade.mov


## What should reviewers focus on?
- you can edit/create a course, and upload an image by clicking save in the edit modal 
- The image should persist

## Testing Procedure
- Create a new course, create some modules in that course
- Upload an image
- Ensure you can see that image in the course preview 
- Ensure that you can see that image when you submit the course image, and that refreshing still contains it

## Checklist
- [X] Ensure code follows style guide by running the linters
- [X] I have updated the documentation or deemed it unnecessary
- [X] I have linked the relevant issue in this PR
- [X] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)