### PR TITLE
Style fixes

### DIFF
--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -93,7 +93,7 @@ const CourseCard = ({
       <Flex
         boxShadow="0px 4px 12px rgba(0, 0, 0, 0.1)"
         direction="column"
-        width="280px"
+        width="100%"
         height="350px"
         borderRadius="8px"
         overflow="hidden"

--- a/frontend/src/components/learner/browser/CourseCard.tsx
+++ b/frontend/src/components/learner/browser/CourseCard.tsx
@@ -93,8 +93,8 @@ const CourseCard = ({
       <Flex
         boxShadow="0px 4px 12px rgba(0, 0, 0, 0.1)"
         direction="column"
-        width="240px"
-        height="300px"
+        width="280px"
+        height="350px"
         borderRadius="8px"
         overflow="hidden"
         position="relative"
@@ -120,8 +120,8 @@ const CourseCard = ({
             overflow="hidden"
             display="-webkit-box"
             sx={{
-              "-webkit-line-clamp": expanded ? "3" : "2",
-              "-webkit-box-orient": "vertical",
+              WebkitLineClamp: expanded ? "4" : "3",
+              WebkitBoxOrient: "vertical",
             }}
           >
             {course.description}

--- a/frontend/src/components/learner/browser/CourseTabs.tsx
+++ b/frontend/src/components/learner/browser/CourseTabs.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Button, ButtonGroup } from "@chakra-ui/react";
+import { Button, Stack } from "@chakra-ui/react";
 import { CheckIcon } from "@chakra-ui/icons";
 
 export const TAB_NAMES = [
@@ -19,11 +19,12 @@ const CourseTabs = ({
   setSelectedTab,
 }: CourseTabsProps): React.ReactElement => {
   return (
-    <ButtonGroup>
+    <Stack direction={["column", "row"]} width="100%">
       {TAB_NAMES.map((name) => {
         const selected = selectedTab === name;
         return (
           <Button
+            width={["100%", "initial"]}
             leftIcon={selected ? <CheckIcon /> : undefined}
             key={name}
             variant={selected ? "md" : "outline-md"}
@@ -33,7 +34,7 @@ const CourseTabs = ({
           </Button>
         );
       })}
-    </ButtonGroup>
+    </Stack>
   );
 };
 

--- a/frontend/src/components/module-viewer/LessonItem.tsx
+++ b/frontend/src/components/module-viewer/LessonItem.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useContext } from "react";
 import {
   Button,
+  Icon,
   IconButton,
   Flex,
   Spacer,
@@ -86,6 +87,19 @@ const LessonItem = ({
     return <LockIcon />;
   };
 
+  const getIconLabel = (): string => {
+    if (editable) {
+      return "";
+    }
+    if (isCurrent) {
+      return "Lesson Status: Current";
+    }
+    if (isCompleted) {
+      return "Lesson Status: Completed";
+    }
+    return "Lesson Status: Locked";
+  };
+
   return (
     <Tooltip
       hasArrow
@@ -119,7 +133,7 @@ const LessonItem = ({
         borderRadius={isFocused ? "0" : undefined}
         bg={isFocused ? "background.light" : undefined}
         textAlign="left"
-        pl={isFocused ? "6px" : "10px"}
+        pl={isFocused ? "6px" : "11px"}
         minH="55px"
         h="min-content"
         w="100%"
@@ -128,13 +142,9 @@ const LessonItem = ({
       >
         <Flex align="center" justify="space-between" pr="8px">
           {!editable && (
-            <IconButton
-              visibility={isHovered ? "visible" : "hidden"}
-              aria-label="Drag Lesson"
-              variant="unstyled"
-              size="xs"
-              icon={getIcon()}
-            />
+            <Icon aria-label={getIconLabel()} viewBox="0 0 20 20">
+              {getIcon()}
+            </Icon>
           )}
           <Text marginLeft="10px">{text}</Text>
           <Spacer />

--- a/frontend/src/components/pages/CourseOverview.tsx
+++ b/frontend/src/components/pages/CourseOverview.tsx
@@ -132,16 +132,80 @@ const CourseOverview = (): React.ReactElement => {
     return "View Course";
   };
 
+  const CTABox = ({ smallVersion = false }: { smallVersion?: boolean }) => {
+    const smallDisplay = smallVersion ? "flex" : "none";
+    const largeDisplay = smallVersion ? "none" : "flex";
+    return (
+      <Flex
+        direction="column"
+        width={["100%", "65%", "26rem"]}
+        maxWidth="100%"
+        height={authenticatedUser ? "100%" : "130%"}
+        background="white"
+        color="text.default"
+        boxShadow="0px 5px 13px rgba(0, 0, 0, 0.1);"
+        borderRadius="8px"
+        overflow={["initial", "initial", "hidden"]}
+        position={["initial", "initial", "relative"]}
+        mt={["1em", "3em", "0px"]}
+        top="90px"
+        pb="24px"
+        display={[smallDisplay, smallDisplay, largeDisplay]}
+      >
+        <Box flex="2" maxHeight="75%">
+          <Image
+            src={courseData?.image || DEFAULT_IMAGE}
+            alt="Course Img"
+            width="100%"
+            height="100%"
+            fit="cover"
+          />
+        </Box>
+        <Box
+          flex="1"
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+          padding="24px 24px 0px 24px"
+        >
+          <Button
+            width="100%"
+            height="100%"
+            onClick={onCTAClick}
+            disabled={disableCTAButton}
+          >
+            {getButtonText()}
+          </Button>
+          {!authenticatedUser && (
+            <Center mt="16px">
+              Already a member?&nbsp;
+              <Button
+                variant="link"
+                color="text.default"
+                onClick={onLogInClick}
+                textDecorationLine="underline"
+              >
+                Log in
+              </Button>
+            </Center>
+          )}
+        </Box>
+      </Flex>
+    );
+  };
+
   return (
-    <Flex direction="column">
+    <Flex direction="column" align={["center", "center", "initial"]}>
       <Banner />
       <Flex
-        px="120px"
+        px={["30px", "120px"]}
         py="20px"
-        height="400px"
+        height={["fit-content", "fit-content", "400px"]}
         background="background.lightgrey"
         color="white"
         align="center"
+        direction={["column", "column", "row"]}
       >
         <VStack flex="2" align="start" spacing={4} pr={6}>
           <Box display="flex">
@@ -163,61 +227,15 @@ const CourseOverview = (): React.ReactElement => {
             lessonCount={getLessonCount()}
           />
         </VStack>
-        <Flex
-          direction="column"
-          width="26rem"
-          height={authenticatedUser ? "100%" : "130%"}
-          background="white"
-          color="text.default"
-          boxShadow="0px 5px 13px rgba(0, 0, 0, 0.1);"
-          borderRadius="8px"
-          overflow="hidden"
-          position="relative"
-          top="90px"
-          pb="24px"
-        >
-          <Box flex="2" maxHeight="75%">
-            <Image
-              src={courseData?.image || DEFAULT_IMAGE}
-              alt="Course Img"
-              width="100%"
-              height="100%"
-              fit="cover"
-            />
-          </Box>
-          <Box
-            flex="1"
-            display="flex"
-            flexDirection="column"
-            justifyContent="center"
-            alignItems="center"
-            padding="24px 24px 0px 24px"
-          >
-            <Button
-              width="100%"
-              height="100%"
-              onClick={onCTAClick}
-              disabled={disableCTAButton}
-            >
-              {getButtonText()}
-            </Button>
-            {!authenticatedUser && (
-              <Center mt="16px">
-                Already a member?&nbsp;
-                <Button
-                  variant="link"
-                  color="text.default"
-                  onClick={onLogInClick}
-                  textDecorationLine="underline"
-                >
-                  Log in
-                </Button>
-              </Center>
-            )}
-          </Box>
-        </Flex>
+        <CTABox />
       </Flex>
-      <VStack w="calc(100% - 28rem)" py="2rem" px="7.5rem" align="left">
+      <CTABox smallVersion />
+      <VStack
+        w={["100%", "100%", "calc(100% - 28rem)"]}
+        py="2rem"
+        px={["30px", "7.5rem"]}
+        align="left"
+      >
         <Text variant="heading">Course Content</Text>
         <ModuleDropdowns
           modules={courseData?.course?.modules}

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -87,7 +87,12 @@ const Default = (): React.ReactElement => {
   return (
     <Flex direction="column">
       <Banner />
-      <VStack align="start" paddingY="80px" paddingX="240px" spacing={5}>
+      <VStack
+        align="start"
+        paddingY="80px"
+        paddingX={["30px", "80px", "240px"]}
+        spacing={5}
+      >
         <Heading as="h2" size="xl">
           Courses
         </Heading>
@@ -98,7 +103,8 @@ const Default = (): React.ReactElement => {
           />
         )}
         <SimpleGrid
-          templateColumns="repeat(auto-fit, 280px)"
+          templateColumns={[null, "repeat(auto-fit, 280px)"]}
+          columns={[1, null]}
           width="100%"
           spacing={5}
         >

--- a/frontend/src/components/pages/Default.tsx
+++ b/frontend/src/components/pages/Default.tsx
@@ -98,7 +98,7 @@ const Default = (): React.ReactElement => {
           />
         )}
         <SimpleGrid
-          templateColumns="repeat(auto-fit, 240px)"
+          templateColumns="repeat(auto-fit, 280px)"
           width="100%"
           spacing={5}
         >

--- a/frontend/src/components/pages/VerifyEmail.tsx
+++ b/frontend/src/components/pages/VerifyEmail.tsx
@@ -44,8 +44,8 @@ const VerifyEmailContent = ({
       return (
         <>
           <Text variant="display-md" paddingBottom="1vw">
-            Please verify your account from the
-            link we sent to your email address!
+            Please verify your account from the link we sent to your email
+            address!
           </Text>
           <Button
             variant="sm"

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -19,6 +19,10 @@ const overrides = {
   colors,
   fonts,
   fontSizes,
+  breakpoints: {
+    sm: "36em",
+    md: "56em",
+  },
 };
 
 export default extendTheme(overrides);


### PR DESCRIPTION

## Implementation Description
- Fix style of lesson items
- Adjust spacing on homepage to support 2-line titles
- Make homepage responsive
- Make course overview page semi-responsive

## Screenshots
See preview URL.

## What should reviewers focus on?
- Do the fixes work as expected?

## Testing Procedure
Open the preview URL, and go through the changes listed above. Verify that the pages work as expected. For checking responsiveness, you can use Chrome's devtools and press Ctrl-Shift-M to change the device. Also verify the pages still look "good" on desktop.

## Things to Note
Did not get to making the module editor responsive, this will probably be a larger undertaking. For responsiveness, the goal was to make learner-facing things responsive, since admins will likely be using a computer.

## Checklist
- [ ] Ensure code follows style guide by running the linters
- [ ] I have updated the documentation or deemed it unnecessary
- [ ] I have linked the relevant issue in this PR
- [ ] I have requested a review from the PL, as well as other dev(s) (and designers if necessary)
